### PR TITLE
When port 8883, default to TLS

### DIFF
--- a/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
+++ b/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
@@ -174,6 +174,14 @@ public class HiveMQClientOptions
         this.KeepAlive = RangeValidateTwoByteInteger(this.KeepAlive);
         this.SessionExpiryInterval = RangeValidateFourByteInteger(this.SessionExpiryInterval);
 
+        // IANA registered ports for MQTT are 1883 (plain) and 8883 (secure).
+        // https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=mqtt
+        // If for any reason you want to disable TLS when using port 8883, use a BeforeConnect event handler.
+        if (this.Port == 8883)
+        {
+            this.UseTLS = true;
+        }
+
         if (this.ClientReceiveMaximum != null)
         {
             this.ClientReceiveMaximum = RangeValidateTwoByteInteger((int)this.ClientReceiveMaximum);


### PR DESCRIPTION
## Description

Port 8883 is [registered with IANA](https://www.iana.org/assignments/service-names-port-numbers/service-names-port-numbers.xhtml?search=mqtt) as "secure MQTT".  When the client is configured to use this port, enable TLS by default.

If for some reason a user wants to disable this, they can use the `BeforeConnect` event handler and set `UseTLS` to false.

Fixes #54
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
