### PR TITLE
Fix QoS2: PubRel packet fix

### DIFF
--- a/Source/HiveMQtt/Client/HiveMQClientEvents.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientEvents.cs
@@ -186,7 +186,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
     protected virtual void OnDisconnectReceivedEventLauncher(DisconnectPacket packet)
     {
         var eventArgs = new OnDisconnectReceivedEventArgs(packet);
-        Trace.WriteLine("OnDisconnectReceivedEventLauncher");
+        Trace.WriteLine("OnDisconnectReceivedEventLauncher: ReasonCode: " + packet.DisconnectReasonCode + " ReasonString: " + packet.Properties.ReasonString);
         this.OnDisconnectReceived?.Invoke(this, eventArgs);
     }
 

--- a/Source/HiveMQtt/MQTT5/Packets/PubRelPacket.cs
+++ b/Source/HiveMQtt/MQTT5/Packets/PubRelPacket.cs
@@ -53,7 +53,7 @@ public class PubRelPacket : ControlPacket
             var constructedPacket = new MemoryStream((int)vhStream.Length + 5);
 
             // Write the Fixed Header
-            var byte1 = (byte)ControlPacketType.PubRec << 4;
+            var byte1 = (byte)ControlPacketType.PubRel << 4;
             byte1 |= 0x2;
             constructedPacket.WriteByte((byte)byte1);
             _ = EncodeVariableByteInteger(constructedPacket, (int)vhStream.Length);

--- a/Tests/HiveMQtt.Test/HiveMQClient/HiveMQClientPublishTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/HiveMQClientPublishTest.cs
@@ -69,6 +69,72 @@ public class HiveMQClientPublishTest
     }
 
     [Fact]
+    public async Task MultiPublishWithQoS0Async()
+    {
+        var client = new HiveMQClient();
+        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+        Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
+
+        var msg = new string(/*lang=json,strict*/ "{\"interference\": \"1029384\"}");
+        Client.Results.PublishResult result;
+
+        for (var i = 1; i <= 10; i++)
+        {
+            result = await client.PublishAsync("tests/MultiPublishWithQoS0Async", msg, MQTT5.Types.QualityOfService.AtMostOnceDelivery).ConfigureAwait(false);
+            Assert.IsType<Client.Results.PublishResult>(result);
+            Assert.Null(result.QoS1ReasonCode);
+            Assert.Null(result.QoS2ReasonCode);
+            Assert.Equal(MQTT5.Types.QualityOfService.AtMostOnceDelivery, result.Message.QoS);
+        }
+
+        var disconnectResult = await client.DisconnectAsync().ConfigureAwait(false);
+        Assert.True(disconnectResult);
+    }
+
+    [Fact]
+    public async Task MultiPublishWithQoS1Async()
+    {
+        var client = new HiveMQClient();
+        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+        Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
+
+        var msg = new string(/*lang=json,strict*/ "{\"interference\": \"1029384\"}");
+        Client.Results.PublishResult result;
+
+        for (var i = 1; i <= 10; i++)
+        {
+            result = await client.PublishAsync("tests/MultiPublishWithQoS1Async", msg, MQTT5.Types.QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+            Assert.IsType<Client.Results.PublishResult>(result);
+            Assert.NotNull(result.QoS1ReasonCode);
+            Assert.Equal(PubAckReasonCode.NoMatchingSubscribers, result?.QoS1ReasonCode);
+        }
+
+        var disconnectResult = await client.DisconnectAsync().ConfigureAwait(false);
+        Assert.True(disconnectResult);
+    }
+
+    [Fact]
+    public async Task MultiPublishWithQoS2Async()
+    {
+        var client = new HiveMQClient();
+        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+        Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
+
+        var msg = new string(/*lang=json,strict*/ "{\"interference\": \"1029384\"}");
+        Client.Results.PublishResult result;
+
+        for (var i = 1; i <= 10; i++)
+        {
+            result = await client.PublishAsync("tests/MultiPublishWithQoS2Async", msg, MQTT5.Types.QualityOfService.ExactlyOnceDelivery).ConfigureAwait(false);
+            Assert.NotNull(result.QoS2ReasonCode);
+            Assert.Equal(PubRecReasonCode.NoMatchingSubscribers, result?.QoS2ReasonCode);
+        }
+
+        var disconnectResult = await client.DisconnectAsync().ConfigureAwait(false);
+        Assert.True(disconnectResult);
+    }
+
+    [Fact]
     public async Task PublishWithOptionsAsync()
     {
         var client = new HiveMQClient();


### PR DESCRIPTION
## Description

Fixes #68

This fixes the PubRel packet which has a malformed fixed header.

Also added more tests to assure sending multiple publishes at QoS 0-2.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

#68

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [X] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
