### PR TITLE
Logging: Connect, Disconnect and TLS metadata

### DIFF
--- a/Source/HiveMQtt/Client/HiveMQClient.cs
+++ b/Source/HiveMQtt/Client/HiveMQClient.cs
@@ -65,6 +65,8 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
     {
         this.connectState = ConnectState.Connecting;
 
+        Logger.Info("Connecting to broker at {0}:{1}", this.Options.Host, this.Options.Port);
+
         // Fire the corresponding event
         this.BeforeConnectEventLauncher(this.Options);
 
@@ -128,6 +130,8 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         }
 
         options ??= new DisconnectOptions();
+
+        Logger.Info("Disconnecting from broker at {0}:{1}", this.Options.Host, this.Options.Port);
 
         // Fire the corresponding event
         this.BeforeDisconnectEventLauncher();

--- a/Source/HiveMQtt/Client/HiveMQClientSocket.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientSocket.cs
@@ -219,6 +219,24 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
             Logger.Trace("Authenticating TLS connection");
             this.stream = new SslStream(stream);
             await ((SslStream)this.stream).AuthenticateAsClientAsync(tlsOptions).ConfigureAwait(false);
+
+            Logger.Info($"Connected via TLS: {((SslStream)this.stream).IsEncrypted}");
+            Logger.Debug($"Cipher Algorithm: {((SslStream)this.stream).CipherAlgorithm}");
+            Logger.Debug($"Cipher Strength: {((SslStream)this.stream).CipherStrength}");
+            Logger.Debug($"Hash Algorithm: {((SslStream)this.stream).HashAlgorithm}");
+            Logger.Debug($"Hash Strength: {((SslStream)this.stream).HashStrength}");
+            Logger.Debug($"Key Exchange Algorithm: {((SslStream)this.stream).KeyExchangeAlgorithm}");
+            Logger.Debug($"Key Exchange Strength: {((SslStream)this.stream).KeyExchangeStrength}");
+
+            var remoteCertificate = ((SslStream)this.stream).RemoteCertificate;
+            if (remoteCertificate != null)
+            {
+                Logger.Info($"Remote Certificate Subject: {remoteCertificate.Subject}");
+                Logger.Info($"Remote Certificate Issuer: {remoteCertificate.Issuer}");
+                Logger.Info($"Remote Certificate Serial Number: {remoteCertificate.GetSerialNumberString()}");
+            }
+
+            Logger.Info($"TLS Protocol: {((SslStream)this.stream).SslProtocol}");
             return true;
         }
         catch (Exception e)

--- a/Source/HiveMQtt/Client/HiveMQClientTrafficProcessor.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientTrafficProcessor.cs
@@ -243,6 +243,9 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
                     {
                         if (decodedPacket is MalformedPacket)
                         {
+                            Logger.Warn($"Malformed packet received.  Disconnecting.");
+                            Logger.Debug($"Malformed packet received: {decodedPacket}");
+
                             var opts = new DisconnectOptions
                             {
                                 ReasonCode = DisconnectReasonCode.MalformedPacket,
@@ -307,6 +310,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
                             break;
                         case DisconnectPacket disconnectPacket:
                             Logger.Trace($"<-- Disconnect id={disconnectPacket.PacketIdentifier}");
+                            Logger.Warn($"Disconnect received: {disconnectPacket.DisconnectReasonCode} {disconnectPacket.Properties.ReasonString}");
                             this.OnDisconnectReceivedEventLauncher(disconnectPacket);
                             break;
                         case PingRespPacket pingRespPacket:
@@ -338,7 +342,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
                             break;
                         default:
                             Logger.Trace("<-- Unknown");
-                            Logger.Error($"Unknown packet received: {packet}");
+                            Logger.Error($"Unrecognized packet received.  Will discard. {packet}");
                             break;
                     } // switch (packet)
                 }


### PR DESCRIPTION
## Description

This PR adds more logging in the right places to illustrate connect/disconnect and TLS options.

How to enable/configure logging is a described in [this documentation](https://hivemq.github.io/hivemq-mqtt-client-dotnet/docs/how-to/configure-logging).

Info Level:
<img width="945" alt="Screenshot 2024-01-31 at 11 12 41" src="https://github.com/hivemq/hivemq-mqtt-client-dotnet/assets/395132/10ea55dd-99f7-43f0-b9d0-0e52c978915b">

With Debug even more TLS information:

<img width="951" alt="Screenshot 2024-01-31 at 11 13 38" src="https://github.com/hivemq/hivemq-mqtt-client-dotnet/assets/395132/e54d7212-6ef8-498e-b4b0-1ff42450d014">

And the very verbose Trace:

<img width="1126" alt="Screenshot 2024-01-31 at 11 29 17" src="https://github.com/hivemq/hivemq-mqtt-client-dotnet/assets/395132/8da496be-d2f8-4529-bf2a-9e44f6494e62">

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
