### PR TITLE
Tests: More Reliable LWT Tests

### DIFF
--- a/Tests/HiveMQtt.Test/HiveMQClient/LWTTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/LWTTest.cs
@@ -41,7 +41,7 @@ public class LWTTest
         {
             messagesReceived++;
             Assert.Equal(QualityOfService.AtLeastOnceDelivery, args.PublishMessage.QoS);
-            Assert.Equal("last/will", args.PublishMessage.Topic);
+            Assert.Equal("last/will2", args.PublishMessage.Topic);
             Assert.Equal("last will message", args.PublishMessage.PayloadAsString);
             Assert.Equal("application/text", args.PublishMessage.ContentType);
             Assert.Equal("response/topic", args.PublishMessage.ResponseTopic);
@@ -58,15 +58,15 @@ public class LWTTest
             taskLWTReceived.SetResult(true);
         };
 
-        var result = await listenerClient.SubscribeAsync("last/will", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+        var result = await listenerClient.SubscribeAsync("last/will2", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
         Assert.Single(result.Subscriptions);
         Assert.Equal(SubAckReasonCode.GrantedQoS1, result.Subscriptions[0].SubscribeReasonCode);
-        Assert.Equal("last/will", result.Subscriptions[0].TopicFilter.Topic);
+        Assert.Equal("last/will2", result.Subscriptions[0].TopicFilter.Topic);
 
         // Setup & Connect another client with a LWT
         var options = new HiveMQClientOptions
         {
-            LastWillAndTestament = new LastWillAndTestament("last/will", "last will message"),
+            LastWillAndTestament = new LastWillAndTestament("last/will2", "last will message"),
         };
 
         options.LastWillAndTestament.WillDelayInterval = 5;
@@ -81,6 +81,8 @@ public class LWTTest
         connectResult = await client.ConnectAsync().ConfigureAwait(false);
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
         Assert.True(client.IsConnected());
+
+        await Task.Delay(5000).ConfigureAwait(false);
 
         // Call DisconnectWithWillMessage.  listenerClient should receive the LWT message
         var disconnectOptions = new DisconnectOptions { ReasonCode = DisconnectReasonCode.DisconnectWithWillMessage };

--- a/Tests/HiveMQtt.Test/HiveMQClient/LWTTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/LWTTest.cs
@@ -10,21 +10,6 @@ using Xunit;
 public class LWTTest
 {
     [Fact]
-    public async Task Basic_Last_Will_Async()
-    {
-        var options = new HiveMQClientOptions
-        {
-            LastWillAndTestament = new LastWillAndTestament("last/will", "last will message"),
-        };
-
-        var client = new HiveMQClient(options);
-
-        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
-        Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
-        Assert.True(client.IsConnected());
-    }
-
-    [Fact]
     public async Task Last_Will_With_Properties_Async()
     {
         // Setup & Connect a client to listen for LWT
@@ -72,6 +57,7 @@ public class LWTTest
         options.LastWillAndTestament.WillDelayInterval = 5;
         options.LastWillAndTestament.PayloadFormatIndicator = 1;
         options.LastWillAndTestament.MessageExpiryInterval = 100;
+        options.LastWillAndTestament.QoS = QualityOfService.AtLeastOnceDelivery;
         options.LastWillAndTestament.ContentType = "application/text";
         options.LastWillAndTestament.ResponseTopic = "response/topic";
         options.LastWillAndTestament.CorrelationData = new byte[] { 1, 2, 3, 4, 5 };
@@ -91,5 +77,8 @@ public class LWTTest
         // Wait until the LWT message is received
         var taskResult = await taskLWTReceived.Task.WaitAsync(TimeSpan.FromSeconds(25)).ConfigureAwait(false);
         Assert.True(taskResult);
+
+        Assert.Equal(1, messagesReceived);
+        await listenerClient.DisconnectAsync().ConfigureAwait(false);
     }
 }

--- a/Tests/HiveMQtt.Test/HiveMQClient/LWTTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/LWTTest.cs
@@ -69,7 +69,7 @@ public class LWTTest
             LastWillAndTestament = new LastWillAndTestament("last/will", "last will message"),
         };
 
-        options.LastWillAndTestament.WillDelayInterval = 1;
+        options.LastWillAndTestament.WillDelayInterval = 5;
         options.LastWillAndTestament.PayloadFormatIndicator = 1;
         options.LastWillAndTestament.MessageExpiryInterval = 100;
         options.LastWillAndTestament.ContentType = "application/text";

--- a/Tests/HiveMQtt.Test/HiveMQClient/LastWillAndTestamentBuilderTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/LastWillAndTestamentBuilderTest.cs
@@ -64,7 +64,7 @@ public class LastWillAndTestamentBuilderTest
             taskLWTReceived.SetResult(true);
         };
 
-        var result = await listenerClient.SubscribeAsync("last/will", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+        var result = await listenerClient.SubscribeAsync("last/will7", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
         Assert.Single(result.Subscriptions);
         Assert.Equal(SubAckReasonCode.GrantedQoS1, result.Subscriptions[0].SubscribeReasonCode);
         Assert.Equal("last/will7", result.Subscriptions[0].TopicFilter.Topic);

--- a/Tests/HiveMQtt.Test/HiveMQClient/LastWillAndTestamentBuilderTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/LastWillAndTestamentBuilderTest.cs
@@ -79,7 +79,7 @@ public class LastWillAndTestamentBuilderTest
             .WithPayloadFormatIndicator(MQTT5PayloadFormatIndicator.UTF8Encoded)
             .WithMessageExpiryInterval(100)
             .WithUserProperty("userPropertyKey", "userPropertyValue")
-            .WithWillDelayInterval(1)
+            .WithWillDelayInterval(6)
             .Build();
 
         // Setup & Connect the client with LWT

--- a/Tests/HiveMQtt.Test/HiveMQClient/LastWillAndTestamentBuilderTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/LastWillAndTestamentBuilderTest.cs
@@ -47,7 +47,7 @@ public class LastWillAndTestamentBuilderTest
         {
             messagesReceived++;
             Assert.Equal(QualityOfService.AtLeastOnceDelivery, args.PublishMessage.QoS);
-            Assert.Equal("last/will", args.PublishMessage.Topic);
+            Assert.Equal("last/will7", args.PublishMessage.Topic);
             Assert.Equal("last will message", args.PublishMessage.PayloadAsString);
             Assert.Equal("application/text", args.PublishMessage.ContentType);
             Assert.Equal("response/topic", args.PublishMessage.ResponseTopic);
@@ -67,10 +67,10 @@ public class LastWillAndTestamentBuilderTest
         var result = await listenerClient.SubscribeAsync("last/will", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
         Assert.Single(result.Subscriptions);
         Assert.Equal(SubAckReasonCode.GrantedQoS1, result.Subscriptions[0].SubscribeReasonCode);
-        Assert.Equal("last/will", result.Subscriptions[0].TopicFilter.Topic);
+        Assert.Equal("last/will7", result.Subscriptions[0].TopicFilter.Topic);
 
         var lwt = new LastWillAndTestamentBuilder()
-            .WithTopic("last/will")
+            .WithTopic("last/will7")
             .WithPayload("last will message")
             .WithQualityOfServiceLevel(QualityOfService.AtLeastOnceDelivery)
             .WithContentType("application/text")
@@ -79,7 +79,7 @@ public class LastWillAndTestamentBuilderTest
             .WithPayloadFormatIndicator(MQTT5PayloadFormatIndicator.UTF8Encoded)
             .WithMessageExpiryInterval(100)
             .WithUserProperty("userPropertyKey", "userPropertyValue")
-            .WithWillDelayInterval(6)
+            .WithWillDelayInterval(5)
             .Build();
 
         // Setup & Connect the client with LWT
@@ -92,6 +92,8 @@ public class LastWillAndTestamentBuilderTest
         connectResult = await client.ConnectAsync().ConfigureAwait(false);
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
         Assert.True(client.IsConnected());
+
+        await Task.Delay(5000).ConfigureAwait(false);
 
         // Call DisconnectWithWillMessage.  listenerClient should receive the LWT message
         var disconnectOptions = new DisconnectOptions { ReasonCode = DisconnectReasonCode.DisconnectWithWillMessage };


### PR DESCRIPTION
## Description

The Github tests occasionally flake out on the Last will and testament tests.  This PR increases the interval a bit to make sure we don't miss the LWT message.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
