### PR TITLE
Use a custom awaitable async queue

### DIFF
--- a/Source/HiveMQtt/Client/internal/AwaitableQueueX.cs
+++ b/Source/HiveMQtt/Client/internal/AwaitableQueueX.cs
@@ -5,23 +5,45 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
+/// <summary>
+/// A queue that can be awaited for items to be enqueued.
+/// </summary>
+/// <typeparam name="T">The type of items to queue.</typeparam>
 public class AwaitableQueueX<T> : IDisposable
 {
+    /// <summary>
+    /// The semaphore used to signal when items are enqueued.
+    /// </summary>
     private readonly SemaphoreSlim semaphore;
+
+    /// <summary>
+    /// The internal queue of items.
+    /// </summary>
     private readonly ConcurrentQueue<T> queue;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AwaitableQueueX{T}"/> class.
+    /// </summary>
     public AwaitableQueueX()
     {
         this.semaphore = new SemaphoreSlim(0);
         this.queue = new ConcurrentQueue<T>();
     }
 
+    /// <summary>
+    /// Enqueues an item.
+    /// </summary>
+    /// <param name="item">The item to enqueue.</param>
     public void Enqueue(T item)
     {
         this.queue.Enqueue(item);
         this.semaphore.Release();
     }
 
+    /// <summary>
+    /// Enqueues a range of items.
+    /// </summary>
+    /// <param name="source">The items to enqueue.</param>
     public void EnqueueRange(IEnumerable<T> source)
     {
         var n = 0;
@@ -34,6 +56,11 @@ public class AwaitableQueueX<T> : IDisposable
         this.semaphore.Release(n);
     }
 
+    /// <summary>
+    /// Dequeues an item.
+    /// </summary>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The dequeued item.</returns>
     public async Task<T> DequeueAsync(CancellationToken cancellationToken)
     {
         while (true)
@@ -47,6 +74,9 @@ public class AwaitableQueueX<T> : IDisposable
         }
     }
 
+    /// <summary>
+    /// Clears the queue.
+    /// </summary>
     public void Clear()
     {
         while (this.queue.TryDequeue(out _))
@@ -55,10 +85,18 @@ public class AwaitableQueueX<T> : IDisposable
         }
     }
 
+    /// <summary>
+    /// Gets the number of items in the queue.
+    /// </summary>
+    /// <value>The number of items in the queue.</value>
     public int Count => this.queue.Count;
 
+    /// <summary>
+    /// Gets a value indicating whether the queue is empty.
+    /// </summary>
     public bool IsEmpty => this.queue.IsEmpty;
 
+    /// <inheritdoc />
     public void Dispose()
     {
         this.semaphore.Dispose();

--- a/Source/HiveMQtt/Client/internal/AwaitableQueueX.cs
+++ b/Source/HiveMQtt/Client/internal/AwaitableQueueX.cs
@@ -81,7 +81,6 @@ public class AwaitableQueueX<T> : IDisposable
     {
         while (this.queue.TryDequeue(out _))
         {
-            this.semaphore.Release();
         }
     }
 

--- a/Source/HiveMQtt/Client/internal/AwaitableQueueX.cs
+++ b/Source/HiveMQtt/Client/internal/AwaitableQueueX.cs
@@ -1,0 +1,67 @@
+namespace HiveMQtt.Client.Internal;
+
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+public class AwaitableQueueX<T> : IDisposable
+{
+    private readonly SemaphoreSlim semaphore;
+    private readonly ConcurrentQueue<T> queue;
+
+    public AwaitableQueueX()
+    {
+        this.semaphore = new SemaphoreSlim(0);
+        this.queue = new ConcurrentQueue<T>();
+    }
+
+    public void Enqueue(T item)
+    {
+        this.queue.Enqueue(item);
+        this.semaphore.Release();
+    }
+
+    public void EnqueueRange(IEnumerable<T> source)
+    {
+        var n = 0;
+        foreach (var item in source)
+        {
+            this.queue.Enqueue(item);
+            n++;
+        }
+
+        this.semaphore.Release(n);
+    }
+
+    public async Task<T> DequeueAsync(CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            await this.semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+            if (this.queue.TryDequeue(out var item))
+            {
+                return item;
+            }
+        }
+    }
+
+    public void Clear()
+    {
+        while (this.queue.TryDequeue(out _))
+        {
+            this.semaphore.Release();
+        }
+    }
+
+    public int Count => this.queue.Count;
+
+    public bool IsEmpty => this.queue.IsEmpty;
+
+    public void Dispose()
+    {
+        this.semaphore.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Tests/HiveMQtt.Test/HiveMQClient/PublishTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/PublishTest.cs
@@ -243,17 +243,17 @@ public class PublishTest
         Assert.Equal(10, client2MessageCount);
         Assert.Equal(10, client3MessageCount);
 
-        Assert.Empty(client1.OutgoingPublishQueue);
-        Assert.Empty(client2.OutgoingPublishQueue);
-        Assert.Empty(client3.OutgoingPublishQueue);
+        Assert.Equal(0, client1.OutgoingPublishQueue.Count);
+        Assert.Equal(0, client2.OutgoingPublishQueue.Count);
+        Assert.Equal(0, client3.OutgoingPublishQueue.Count);
 
-        Assert.Empty(client1.ReceivedQueue);
-        Assert.Empty(client2.ReceivedQueue);
-        Assert.Empty(client3.ReceivedQueue);
+        Assert.Equal(0, client1.ReceivedQueue.Count);
+        Assert.Equal(0, client2.ReceivedQueue.Count);
+        Assert.Equal(0, client3.ReceivedQueue.Count);
 
-        Assert.Empty(client1.SendQueue);
-        Assert.Empty(client2.SendQueue);
-        Assert.Empty(client3.SendQueue);
+        Assert.Equal(0, client1.SendQueue.Count);
+        Assert.Equal(0, client2.SendQueue.Count);
+        Assert.Equal(0, client3.SendQueue.Count);
 
         Assert.Empty(client1.TransactionQueue);
         Assert.Empty(client2.TransactionQueue);
@@ -334,17 +334,17 @@ public class PublishTest
         Assert.Equal(10, client2MessageCount);
         Assert.Equal(10, client3MessageCount);
 
-        Assert.Empty(client1.OutgoingPublishQueue);
-        Assert.Empty(client2.OutgoingPublishQueue);
-        Assert.Empty(client3.OutgoingPublishQueue);
+        Assert.Equal(0, client1.OutgoingPublishQueue.Count);
+        Assert.Equal(0, client2.OutgoingPublishQueue.Count);
+        Assert.Equal(0, client3.OutgoingPublishQueue.Count);
 
-        Assert.Empty(client1.ReceivedQueue);
-        Assert.Empty(client2.ReceivedQueue);
-        Assert.Empty(client3.ReceivedQueue);
+        Assert.Equal(0, client1.ReceivedQueue.Count);
+        Assert.Equal(0, client2.ReceivedQueue.Count);
+        Assert.Equal(0, client3.ReceivedQueue.Count);
 
-        Assert.Empty(client1.SendQueue);
-        Assert.Empty(client2.SendQueue);
-        Assert.Empty(client3.SendQueue);
+        Assert.Equal(0, client1.SendQueue.Count);
+        Assert.Equal(0, client2.SendQueue.Count);
+        Assert.Equal(0, client3.SendQueue.Count);
 
         Assert.Empty(client1.TransactionQueue);
         Assert.Empty(client2.TransactionQueue);
@@ -424,17 +424,17 @@ public class PublishTest
         Assert.Equal(10, client2MessageCount);
         Assert.Equal(10, client3MessageCount);
 
-        Assert.Empty(client1.OutgoingPublishQueue);
-        Assert.Empty(client2.OutgoingPublishQueue);
-        Assert.Empty(client3.OutgoingPublishQueue);
+        Assert.Equal(0, client1.OutgoingPublishQueue.Count);
+        Assert.Equal(0, client2.OutgoingPublishQueue.Count);
+        Assert.Equal(0, client3.OutgoingPublishQueue.Count);
 
-        Assert.Empty(client1.ReceivedQueue);
-        Assert.Empty(client2.ReceivedQueue);
-        Assert.Empty(client3.ReceivedQueue);
+        Assert.Equal(0, client1.ReceivedQueue.Count);
+        Assert.Equal(0, client2.ReceivedQueue.Count);
+        Assert.Equal(0, client3.ReceivedQueue.Count);
 
-        Assert.Empty(client1.SendQueue);
-        Assert.Empty(client2.SendQueue);
-        Assert.Empty(client3.SendQueue);
+        Assert.Equal(0, client1.SendQueue.Count);
+        Assert.Equal(0, client2.SendQueue.Count);
+        Assert.Equal(0, client3.SendQueue.Count);
 
         Assert.Empty(client1.TransactionQueue);
         Assert.Empty(client2.TransactionQueue);

--- a/Tests/HiveMQtt.Test/Queues/AwaitableQueueXTest.cs
+++ b/Tests/HiveMQtt.Test/Queues/AwaitableQueueXTest.cs
@@ -1,0 +1,74 @@
+namespace HiveMQtt.Test.Packets;
+
+using HiveMQtt.Client.Options;
+using HiveMQtt.Client.Internal;
+using HiveMQtt.MQTT5.Packets;
+using HiveMQtt.MQTT5;
+using Xunit;
+
+public class AwaitableQueueXTest
+{
+    [Fact]
+    public async Task WaitWhenEmptyAsync()
+    {
+        var queue = new AwaitableQueueX<ControlPacket>();
+        Assert.True(queue.IsEmpty);
+
+        var options = new HiveMQClientOptions();
+        Assert.NotNull(options);
+
+        var packet = new ConnectPacket(options);
+        queue.Enqueue(packet);
+        Assert.Equal(1, queue.Count);
+
+        var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+
+        ControlPacket? firstResult = null;
+        ControlPacket? secondResult = null;
+        var operationCanceled = false;
+        try
+        {
+            // Get the first packet
+            firstResult = await queue.DequeueAsync(cts.Token).ConfigureAwait(false);
+            Assert.NotNull(firstResult);
+            Assert.Equal(packet, firstResult);
+
+            // The second dequeue call should wait until the cancellation token is timeout canceled
+            secondResult = await queue.DequeueAsync(cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            operationCanceled = true;
+            Assert.NotNull(firstResult);
+            Assert.Null(secondResult);
+        }
+
+        Assert.True(operationCanceled);
+    }
+
+    [Fact]
+    public void CanBeCleared()
+    {
+        var queue = new AwaitableQueueX<ControlPacket>();
+        Assert.True(queue.IsEmpty);
+
+        var options = new HiveMQClientOptions();
+        Assert.NotNull(options);
+
+        var packetOne = new ConnectPacket(options);
+        queue.Enqueue(packetOne);
+        Assert.Equal(1, queue.Count);
+
+        var packetTwo = new ConnectPacket(options);
+        queue.Enqueue(packetTwo);
+        Assert.Equal(2, queue.Count);
+
+        var packetThree = new ConnectPacket(options);
+        queue.Enqueue(packetThree);
+        Assert.Equal(3, queue.Count);
+
+        queue.Clear();
+        Assert.True(queue.IsEmpty);
+        Assert.Equal(0, queue.Count);
+    }
+}


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

This PR implements a new `AwaitableQueueX` custom class that manages an underlying `ConcurrentQueue` with a semaphore that can be asynchronously awaited on.  This avoids any type of thread blocking or the need for custom (and inefficient) delays or sleeps.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
