### PR TITLE
Subscribe: Better transaction management

### DIFF
--- a/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
+++ b/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
@@ -276,9 +276,10 @@ public class HiveMQClientOptions
         {
             this.GenerateClientID();
         }
-        else if (this.ClientId.Length > 23)
+
+        if (this.ClientId.Length > 23)
         {
-            // FIXME: Warn on exceeded length; can use but it may not work...
+            Logger.Info($"Client ID {this.ClientId} is longer than 23 characters.  This may cause issues with some brokers.");
         }
     }
 


### PR DESCRIPTION
## Description

This PR make `SubscribePacket` awaitable for the returned SubAck.  It also ensures that we have only one subscribe in flight at any given time.

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
