### PR TITLE
Improved Disconnect Error Handling

### DIFF
--- a/Source/HiveMQtt/Client/HiveMQClient.cs
+++ b/Source/HiveMQtt/Client/HiveMQClient.cs
@@ -513,6 +513,12 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
     /// <param name="clean">Indicates whether the disconnect was intended or not.</param>
     private async Task<bool> HandleDisconnectionAsync(bool clean = true)
     {
+        if (this.ConnectState == ConnectState.Disconnected)
+        {
+            Logger.Trace("HandleDisconnection: Already disconnected.");
+            return false;
+        }
+
         Logger.Debug($"HandleDisconnection: Handling disconnection. clean={clean}.");
 
         // Cancel all background tasks and close the socket

--- a/Source/HiveMQtt/Client/HiveMQClientSocket.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientSocket.cs
@@ -213,7 +213,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         }
         else
         {
-            tlsOptions.RemoteCertificateValidationCallback = HiveMQClient.ValidateServerCertificate;
+            tlsOptions.RemoteCertificateValidationCallback = ValidateServerCertificate;
         }
 
         try

--- a/Source/HiveMQtt/Client/HiveMQClientTrafficProcessor.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientTrafficProcessor.cs
@@ -327,6 +327,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
                             Logger.Debug($"{this.Options.ClientId}-(W)- ConnectionWriter IsCompleted: this was unexpected");
                             await this.HandleDisconnectionAsync(false).ConfigureAwait(false);
                         }
+
                         Logger.Info($"{this.Options.ClientId}-(W)- ConnectionWriter Exiting...{this.ConnectState}");
                         return;
                     }
@@ -428,8 +429,6 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
                         // We handle disconnects immediately
                         if (decodedPacket is DisconnectPacket disconnectPacket)
                         {
-                            // FIXME: If we received disconnect another client with the same id connected else where, should we
-                            // Call the OnDisconnectReceivedEventLauncher?
                             Logger.Error($"--> Disconnect received <--: {disconnectPacket.DisconnectReasonCode} {disconnectPacket.Properties.ReasonString}");
                             await this.HandleDisconnectionAsync(false).ConfigureAwait(false);
                             this.OnDisconnectReceivedEventLauncher(disconnectPacket);
@@ -461,9 +460,6 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
                         // Add the packet to the received queue for processing later by ReceivedPacketsHandlerAsync
                         this.ReceivedQueue.Enqueue(decodedPacket);
                     } // while (buffer.Length > 0
-
-                    // FIXME
-                    await Task.Yield();
                 }
                 catch (TaskCanceledException)
                 {
@@ -783,7 +779,6 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         }
 
         this.SendQueue.Enqueue(pubCompResponsePacket);
-
     }
 
     /// <summary>

--- a/Source/HiveMQtt/Client/HiveMQClientUtil.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientUtil.cs
@@ -87,7 +87,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         if (pattern == "#")
         {
             // A subscription to “#” will not receive any messages published to a topic beginning with a $
-            if (candidate.StartsWith("$", System.StringComparison.CurrentCulture))
+            if (candidate.StartsWith("$", StringComparison.CurrentCulture))
             {
                 return false;
             }
@@ -100,8 +100,8 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         if (pattern == "+")
         {
             // A subscription to “+” will not receive any messages published to a topic beginning with a $ or /
-            if (candidate.StartsWith("$", System.StringComparison.CurrentCulture) ||
-                candidate.StartsWith("/", System.StringComparison.CurrentCulture))
+            if (candidate.StartsWith("$", StringComparison.CurrentCulture) ||
+                candidate.StartsWith("/", StringComparison.CurrentCulture))
             {
                 return false;
             }
@@ -126,7 +126,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         var regexp = "\\A" + Regex.Escape(pattern).Replace(@"\+", @"?[/][^/]*") + "\\z";
 
         regexp = regexp.Replace(@"/\#", @"(/?|.+)");
-        regexp = regexp.EndsWith("\\z", System.StringComparison.CurrentCulture) ? regexp : regexp + "\\z";
+        regexp = regexp.EndsWith("\\z", StringComparison.CurrentCulture) ? regexp : regexp + "\\z";
 
         return Regex.IsMatch(candidate, regexp);
     }
@@ -168,7 +168,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
     /// or indirectly by a user's code. Managed and unmanaged resources
     /// can be disposed.
     /// If disposing equals false, the method has been called by the
-    /// runtime from inside the finalizer and you should not reference
+    /// runtime from inside finalize and you should not reference
     /// other objects. Only unmanaged resources can be disposed.
     /// </summary>
     /// <param name="disposing">True if called from user code.</param>

--- a/Source/HiveMQtt/Client/IHiveMQClient.cs
+++ b/Source/HiveMQtt/Client/IHiveMQClient.cs
@@ -78,7 +78,7 @@ public interface IHiveMQClient : IDisposable
     /// <summary>
     /// Publish a message to an MQTT topic.
     /// <para>
-    /// This is a convenience method that routes to <seealso cref="PublishAsync(MQTT5PublishMessage)"/>.
+    /// This is a convenience method that routes to <seealso cref="PublishAsync(MQTT5PublishMessage, CancellationToken)"/>.
     /// </para>
     /// </summary>
     /// <param name="topic">The string topic to publish to.</param>
@@ -90,7 +90,7 @@ public interface IHiveMQClient : IDisposable
     /// <summary>
     /// Publish a message to an MQTT topic.
     /// <para>
-    /// This is a convenience method that routes to <seealso cref="PublishAsync(MQTT5PublishMessage)"/>.
+    /// This is a convenience method that routes to <seealso cref="PublishAsync(MQTT5PublishMessage, CancellationToken)"/>.
     /// </para>
     /// </summary>
     /// <param name="topic">The string topic to publish to.</param>

--- a/Source/HiveMQtt/Client/IHiveMQClient.cs
+++ b/Source/HiveMQtt/Client/IHiveMQClient.cs
@@ -71,8 +71,9 @@ public interface IHiveMQClient : IDisposable
     /// Publish a message to an MQTT topic.
     /// </summary>
     /// <param name="message">The <seealso cref="MQTT5PublishMessage"/> for the Publish.</param>
+    /// <param name="cancellationToken">A <seealso cref="CancellationToken"/> to cancel the operation.</param>
     /// <returns>A <seealso cref="PublishResult"/> representing the result of the publish operation.</returns>
-    Task<PublishResult> PublishAsync(MQTT5PublishMessage message);
+    Task<PublishResult> PublishAsync(MQTT5PublishMessage message, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Publish a message to an MQTT topic.

--- a/Source/HiveMQtt/Client/internal/BoundedDictionaryX.cs
+++ b/Source/HiveMQtt/Client/internal/BoundedDictionaryX.cs
@@ -42,7 +42,7 @@ public class BoundedDictionaryX<TKey, TVal> : IDisposable
     }
 
     /// <summary>
-    /// Attempts to add an item to the dictionary.
+    /// Attempts to add an item to the dictionary.  If there is not slot available, this method will asynchronously wait for an available slot.
     /// </summary>
     /// <param name="key">The key to add.</param>
     /// <param name="value">The value to add.</param>


### PR DESCRIPTION
## Description

With this PR, `PublishAsync` now blocks until the publish is executed.  This means that if we get disconnected during a publish, it will continue to block until reconnected or the task is cancelled with the new `CancellationToken` parameter.



## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
