### PR TITLE
E2E Test Coverage Part 1

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,15 +2,19 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
       - uses: release-drafter/release-drafter@v6.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Source/HiveMQtt/Client/DisconnectOptionsBuilder.cs
+++ b/Source/HiveMQtt/Client/DisconnectOptionsBuilder.cs
@@ -111,10 +111,41 @@ public class DisconnectOptionsBuilder
         return this;
     }
 
+    /// <summary>
+    /// Adds a dictionary of user properties to the disconnect.
+    /// </summary>
+    /// <param name="properties">The dictionary of user properties to add.</param>
+    /// <returns>The builder instance.</returns>
+    /// <exception cref="ArgumentException">Thrown if a key or value is not between 1 and 65535 characters.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if the key or value is null.</exception>
     public DisconnectOptionsBuilder WithUserProperties(Dictionary<string, string> properties)
     {
         foreach (var property in properties)
         {
+            if (property.Key is null)
+            {
+                Logger.Error("User property key cannot be null.");
+                throw new ArgumentNullException(nameof(properties));
+            }
+
+            if (property.Value is null)
+            {
+                Logger.Error("User property value cannot be null.");
+                throw new ArgumentNullException(nameof(properties));
+            }
+
+            if (property.Key.Length is < 1 or > 65535)
+            {
+                Logger.Error("User property key must be between 1 and 65535 characters.");
+                throw new ArgumentException("User property key must be between 1 and 65535 characters.");
+            }
+
+            if (property.Value.Length is < 1 or > 65535)
+            {
+                Logger.Error("User property value must be between 1 and 65535 characters.");
+                throw new ArgumentException("User property value must be between 1 and 65535 characters.");
+            }
+
             this.options.UserProperties.Add(property.Key, property.Value);
         }
 

--- a/Source/HiveMQtt/Client/DisconnectOptionsBuilder.cs
+++ b/Source/HiveMQtt/Client/DisconnectOptionsBuilder.cs
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2024-present HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace HiveMQtt.Client;
+
+using HiveMQtt.Client.Options;
+using HiveMQtt.MQTT5.ReasonCodes;
+
+public class DisconnectOptionsBuilder
+{
+    private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+
+    private readonly DisconnectOptions options;
+
+    public DisconnectOptionsBuilder() => this.options = new DisconnectOptions();
+
+    /// <summary>
+    /// Sets the session expiry interval for the disconnect.
+    /// </summary>
+    /// <param name="sessionExpiryInterval">The session expiry interval in seconds.</param>
+    /// <returns>The builder instance.</returns>
+    public DisconnectOptionsBuilder WithSessionExpiryInterval(int sessionExpiryInterval)
+    {
+        this.options.SessionExpiryInterval = sessionExpiryInterval;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the reason code for the disconnect.
+    /// </summary>
+    /// <param name="reasonCode">The reason code for the disconnect.</param>
+    /// <returns>The builder instance.</returns>
+    public DisconnectOptionsBuilder WithReasonCode(DisconnectReasonCode reasonCode)
+    {
+        this.options.ReasonCode = reasonCode;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the reason string for the disconnect.
+    /// </summary>
+    /// <param name="reasonString">The reason string for the disconnect.</param>
+    /// <returns>The builder instance.</returns>
+    /// <exception cref="ArgumentException">Thrown if the reason string is not between 1 and 65535 characters.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if the reason string is null.</exception>
+    public DisconnectOptionsBuilder WithReasonString(string reasonString)
+    {
+        if (reasonString is null)
+        {
+            Logger.Error("Reason string cannot be null.");
+            throw new ArgumentNullException(nameof(reasonString));
+        }
+
+        if (reasonString.Length is < 1 or > 65535)
+        {
+            Logger.Error("Reason string must be between 1 and 65535 characters.");
+            throw new ArgumentException("Reason string must be between 1 and 65535 characters.");
+        }
+
+        this.options.ReasonString = reasonString;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a user property to the disconnect.
+    /// </summary>
+    /// <param name="key">The key for the user property.</param>
+    /// <param name="value">The value for the user property.</param>
+    /// <returns>The builder instance.</returns>
+    /// <exception cref="ArgumentException">Thrown if the key or value is not between 1 and 65535 characters.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if the key or value is null.</exception>
+    public DisconnectOptionsBuilder WithUserProperty(string key, string value)
+    {
+        if (key is null)
+        {
+            Logger.Error("User property key cannot be null.");
+            throw new ArgumentNullException(nameof(key));
+        }
+
+        if (value is null)
+        {
+            Logger.Error("User property value cannot be null.");
+            throw new ArgumentNullException(nameof(value));
+        }
+
+        if (key.Length is < 1 or > 65535)
+        {
+            Logger.Error("User property key must be between 1 and 65535 characters.");
+            throw new ArgumentException("User property key must be between 1 and 65535 characters.");
+        }
+
+        if (value.Length is < 1 or > 65535)
+        {
+            Logger.Error("User property value must be between 1 and 65535 characters.");
+            throw new ArgumentException("User property value must be between 1 and 65535 characters.");
+        }
+
+        this.options.UserProperties.Add(key, value);
+        return this;
+    }
+
+    public DisconnectOptionsBuilder WithUserProperties(Dictionary<string, string> properties)
+    {
+        foreach (var property in properties)
+        {
+            this.options.UserProperties.Add(property.Key, property.Value);
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the SubscribeOptions based on the previous calls.  This
+    /// step will also run validation on the final SubscribeOptions.
+    /// </summary>
+    /// <returns>The constructed SubscribeOptions instance.</returns>
+    public DisconnectOptions Build()
+    {
+        this.options.Validate();
+        return this.options;
+    }
+}

--- a/Source/HiveMQtt/Client/HiveMQClient.cs
+++ b/Source/HiveMQtt/Client/HiveMQClient.cs
@@ -153,7 +153,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         // Fire the corresponding event
         this.BeforeDisconnectEventLauncher();
 
-        var disconnectPacket = new DisconnectPacket
+        var disconnectPacket = new DisconnectPacket(options)
         {
             DisconnectReasonCode = options.ReasonCode,
         };

--- a/Source/HiveMQtt/Client/HiveMQClientOptionsBuilder.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientOptionsBuilder.cs
@@ -280,8 +280,15 @@ public class HiveMQClientOptionsBuilder
     /// </summary>
     /// <param name="method">The authentication method.</param>
     /// <returns>The HiveMQClientOptionsBuilder instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when the authentication method is not between 1 and 65535 characters.</exception>
     public HiveMQClientOptionsBuilder WithAuthenticationMethod(string method)
     {
+        if (method.Length is < 1 or > 65535)
+        {
+            Logger.Error("Authentication method must be between 1 and 65535 characters.");
+            throw new ArgumentException("Authentication method must be between 1 and 65535 characters.");
+        }
+
         this.options.AuthenticationMethod = method;
         return this;
     }

--- a/Source/HiveMQtt/Client/HiveMQClientOptionsBuilder.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientOptionsBuilder.cs
@@ -125,6 +125,11 @@ public class HiveMQClientOptionsBuilder
     /// <returns>The HiveMQClientOptionsBuilder instance.</returns>
     public HiveMQClientOptionsBuilder WithClientId(string clientId)
     {
+        if (clientId.Length is < 0 or > 65535)
+        {
+            Logger.Error("Client Id must be between 0 and 65535 characters.");
+            throw new ArgumentException("Client Id must be between 0 and 65535 characters.");
+        }
         this.options.ClientId = clientId;
         return this;
     }
@@ -309,6 +314,18 @@ public class HiveMQClientOptionsBuilder
     /// <returns>The HiveMQClientOptionsBuilder instance.</returns>
     public HiveMQClientOptionsBuilder WithUserProperty(string key, string value)
     {
+        if (key.Length is < 1 or > 65535)
+        {
+            Logger.Error("User property key must be between 1 and 65535 characters.");
+            throw new ArgumentException("User property key must be between 1 and 65535 characters.");
+        }
+
+        if (value.Length is < 1 or > 65535)
+        {
+            Logger.Error("User property value must be between 1 and 65535 characters.");
+            throw new ArgumentException("User property value must be between 1 and 65535 characters.");
+        }
+
         this.options.UserProperties.Add(key, value);
         return this;
     }
@@ -432,6 +449,12 @@ public class HiveMQClientOptionsBuilder
     /// <returns>The HiveMQClientOptionsBuilder instance.</returns>
     public HiveMQClientOptionsBuilder WithUserName(string username)
     {
+        if (username.Length is < 0 or > 65535)
+        {
+            Logger.Error("Username must be between 0 and 65535 characters.");
+            throw new ArgumentException("Username must be between 0 and 65535 characters.");
+        }
+
         this.options.UserName = username;
         return this;
     }
@@ -462,6 +485,11 @@ public class HiveMQClientOptionsBuilder
     /// <returns>The HiveMQClientOptionsBuilder instance.</returns>
     public HiveMQClientOptionsBuilder WithPassword(string password)
     {
+        if (password.Length is < 0 or > 65535)
+        {
+            Logger.Error("Password must be between 0 and 65535 characters.");
+            throw new ArgumentException("Password must be between 0 and 65535 characters.");
+        }
         this.options.Password = password;
         return this;
     }

--- a/Source/HiveMQtt/Client/HiveMQClientOptionsBuilder.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientOptionsBuilder.cs
@@ -130,6 +130,7 @@ public class HiveMQClientOptionsBuilder
             Logger.Error("Client Id must be between 0 and 65535 characters.");
             throw new ArgumentException("Client Id must be between 0 and 65535 characters.");
         }
+
         this.options.ClientId = clientId;
         return this;
     }
@@ -497,6 +498,7 @@ public class HiveMQClientOptionsBuilder
             Logger.Error("Password must be between 0 and 65535 characters.");
             throw new ArgumentException("Password must be between 0 and 65535 characters.");
         }
+
         this.options.Password = password;
         return this;
     }

--- a/Source/HiveMQtt/Client/HiveMQClientUtil.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientUtil.cs
@@ -173,7 +173,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
                     Logger.Trace("HiveMQClient Dispose: Disconnecting connected client.");
                     _ = Task.Run(async () => await this.DisconnectAsync().ConfigureAwait(false));
                 }
-             }
+            }
 
             // Call the appropriate methods to clean up
             // unmanaged resources here.

--- a/Source/HiveMQtt/Client/Options/DisconnectOptions.cs
+++ b/Source/HiveMQtt/Client/Options/DisconnectOptions.cs
@@ -15,6 +15,7 @@
  */
 namespace HiveMQtt.Client.Options;
 
+using HiveMQtt.Client.Exceptions;
 using HiveMQtt.MQTT5.ReasonCodes;
 
 /// <summary>
@@ -41,7 +42,7 @@ public class DisconnectOptions
     /// to the indicated value.  The value represents the session expiration time
     /// in seconds.
     /// </summary>
-    public int? SessionExpiry { get; set; }
+    public int? SessionExpiryInterval { get; set; }
 
     /// <summary>
     /// Gets or sets the reason string for the disconnection.  This is a human readable
@@ -53,4 +54,32 @@ public class DisconnectOptions
     /// Gets or sets the user properties for the disconnection.
     /// </summary>
     public Dictionary<string, string> UserProperties { get; set; }
+
+    /// <summary>
+    /// Validate that the options in this instance are valid.
+    /// </summary>
+    /// <exception cref="HiveMQttClientException">The exception raised if some value is out of range or invalid.</exception>
+    public void Validate()
+    {
+        // Validate SessionExpiry is non-negative if provided
+        if (this.SessionExpiryInterval.HasValue && this.SessionExpiryInterval < 0)
+        {
+            throw new HiveMQttClientException("Session expiry must be a non-negative value.");
+        }
+
+        // Validate ReasonString length (assuming max length of 65535 characters)
+        if (this.ReasonString != null && this.ReasonString.Length > 65535)
+        {
+            throw new HiveMQttClientException("Reason string must not exceed 65535 characters.");
+        }
+
+        // Validate UserProperties for null keys or values
+        foreach (var kvp in this.UserProperties)
+        {
+            if (kvp.Key == null || kvp.Value == null)
+            {
+                throw new HiveMQttClientException("User properties must not have null keys or values.");
+            }
+        }
+    }
 }

--- a/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
+++ b/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
@@ -63,6 +63,7 @@ public class HiveMQClientOptions
     /// Examples:
     /// ws://localhost:8000/mqtt
     /// wss://localhost:8884/mqtt
+    /// .
     /// </para>
     /// </summary>
     public string WebSocketServer { get; set; }

--- a/Source/HiveMQtt/Client/PublishMessageBuilder.cs
+++ b/Source/HiveMQtt/Client/PublishMessageBuilder.cs
@@ -62,8 +62,27 @@ public class PublishMessageBuilder
     /// </summary>
     /// <param name="topic">The topic.</param>
     /// <returns>The builder instance.</returns>
+    /// <exception cref="ArgumentException">Thrown when the topic is null or empty.</exception>
+    /// <exception cref="ArgumentException">Thrown when the topic length is greater than 65535 characters.</exception>
+    /// <exception cref="ArgumentException">Thrown when the topic contains wildcard characters.</exception>
     public PublishMessageBuilder WithTopic(string topic)
     {
+        if (string.IsNullOrEmpty(topic))
+        {
+            throw new ArgumentException("Topic must not be null or empty.");
+        }
+
+        if (topic.Length is < 1 or > 65535)
+        {
+            throw new ArgumentException("Topic must be between 1 and 65535 characters.");
+        }
+
+        // The topic string should not contain any wildcard characters.
+        if (topic.Contains('+') || topic.Contains('#'))
+        {
+            throw new ArgumentException("Topic must not contain wildcard characters.  Use TopicFilter instead.");
+        }
+
         this.message.Topic = topic;
         return this;
     }

--- a/Source/HiveMQtt/Client/Transport/WebSocketTransport.cs
+++ b/Source/HiveMQtt/Client/Transport/WebSocketTransport.cs
@@ -123,8 +123,8 @@ public class WebSocketTransport : BaseTransport, IDisposable
 
             Logger.Trace($"Received {ms.Length} bytes");
 
+            // Development
             // ms.Seek(0, SeekOrigin.Begin);
-
             if (result.MessageType == WebSocketMessageType.Binary)
             {
                 // Prepare the result and return

--- a/Source/HiveMQtt/MQTT5/Packets/ConnectPacket.cs
+++ b/Source/HiveMQtt/MQTT5/Packets/ConnectPacket.cs
@@ -121,7 +121,7 @@ public class ConnectPacket : ControlPacket
         this.clientOptions.Validate();
 
         this.flags = 0x0;
-        if (this.clientOptions.CleanStart is true)
+        if (this.clientOptions.CleanStart)
         {
             this.flags |= 0x2;
         }

--- a/Source/HiveMQtt/MQTT5/Packets/PubCompPacket.cs
+++ b/Source/HiveMQtt/MQTT5/Packets/PubCompPacket.cs
@@ -45,7 +45,7 @@ public class PubCompPacket : ControlPacket
         using (var vhStream = new MemoryStream())
         {
             // Variable Header
-            ControlPacket.EncodeTwoByteInteger(vhStream, this.PacketIdentifier);
+            EncodeTwoByteInteger(vhStream, this.PacketIdentifier);
             vhStream.WriteByte((byte)this.ReasonCode);
             this.EncodeProperties(vhStream);
 

--- a/Source/HiveMQtt/MQTT5/Packets/PubRecPacket.cs
+++ b/Source/HiveMQtt/MQTT5/Packets/PubRecPacket.cs
@@ -45,7 +45,7 @@ public class PubRecPacket : ControlPacket
         using (var vhStream = new MemoryStream())
         {
             // Variable Header
-            ControlPacket.EncodeTwoByteInteger(vhStream, this.PacketIdentifier);
+            EncodeTwoByteInteger(vhStream, this.PacketIdentifier);
             vhStream.WriteByte((byte)this.ReasonCode);
             this.EncodeProperties(vhStream);
 

--- a/Source/HiveMQtt/MQTT5/Packets/PubRelPacket.cs
+++ b/Source/HiveMQtt/MQTT5/Packets/PubRelPacket.cs
@@ -45,7 +45,7 @@ public class PubRelPacket : ControlPacket
         using (var vhStream = new MemoryStream())
         {
             // Variable Header
-            ControlPacket.EncodeTwoByteInteger(vhStream, this.PacketIdentifier);
+            EncodeTwoByteInteger(vhStream, this.PacketIdentifier);
             vhStream.WriteByte((byte)this.ReasonCode);
             this.EncodeProperties(vhStream);
 

--- a/Source/HiveMQtt/MQTT5/Packets/PublishPacket.cs
+++ b/Source/HiveMQtt/MQTT5/Packets/PublishPacket.cs
@@ -293,7 +293,7 @@ public class PublishPacket : ControlPacket
             var byte1 = (byte)ControlPacketType.Publish << 4;
 
             // DUP Flag
-            if (this.Message.Duplicate is true)
+            if (this.Message.Duplicate)
             {
                 byte1 |= 0x8;
             }
@@ -309,7 +309,7 @@ public class PublishPacket : ControlPacket
             }
 
             // Retain Flag
-            if (this.Message.Retain is true)
+            if (this.Message.Retain)
             {
                 byte1 |= 0x1;
             }

--- a/Tests/HiveMQtt.Test/HiveMQClient/Plan/Utf8LimitTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/Plan/Utf8LimitTest.cs
@@ -1,0 +1,123 @@
+namespace HiveMQtt.Test.HiveMQClient.Plan;
+
+using FluentAssertions;
+using HiveMQtt.Client;
+using HiveMQtt.MQTT5.Types;
+using NUnit.Framework;
+
+[TestFixture]
+public class Utf8LimitTest
+{
+    [Test]
+    public void ClientId_Should_Allow_0_To_65535_Characters()
+    {
+        var clientId = GenerateUtf8String(65535);
+        var options = new HiveMQClientOptionsBuilder()
+                        .WithClientId(clientId)
+                        .Build();
+        var client = new HiveMQClient(options);
+
+        client.Should().NotBeNull();
+    }
+
+    [Test]
+    public void ClientId_Should_Disallow_Exceeding_65535_Characters()
+    {
+        var clientId = GenerateUtf8String(65536);
+        Action act = () => new HiveMQClientOptionsBuilder().WithClientId(clientId).Build();
+
+        act.Should().Throw<ArgumentException>().WithMessage("Client Id must be between 0 and 65535 characters.");
+    }
+
+    [Test]
+    public void UserPropertiesKey_And_Value_Should_Allow_0_To_65535_Characters()
+    {
+        var key = GenerateUtf8String(65535);
+        var value = GenerateUtf8String(65535);
+        var options = new HiveMQClientOptionsBuilder()
+                        .WithUserProperty(key, value)
+                        .Build();
+        var client = new HiveMQClient(options);
+
+        client.Should().NotBeNull();
+    }
+
+    [Test]
+    public void LastWillAndTestament_ResponseTopic_Should_Allow_0_To_65535_Characters()
+    {
+        var responseTopic = GenerateUtf8String(65535);
+        var lwt = new LastWillAndTestamentBuilder()
+                .WithTopic("last/will")
+                .WithPayload("last will message")
+                .WithQualityOfServiceLevel(QualityOfService.AtLeastOnceDelivery)
+                .WithResponseTopic(responseTopic)
+                .Build();
+
+        var options = new HiveMQClientOptionsBuilder()
+                    .WithLastWillAndTestament(lwt)
+                    .Build();
+
+        var client = new HiveMQClient(options);
+
+        client.Should().NotBeNull();
+    }
+
+    [Test]
+    public void UserName_Should_Allow_0_To_65535_Characters()
+    {
+        var userName = GenerateUtf8String(65535);
+        var options = new HiveMQClientOptionsBuilder()
+                        .WithUserName(userName)
+                        .Build();
+        var client = new HiveMQClient(options);
+
+        client.Should().NotBeNull();
+    }
+
+    [Test]
+    public void LastWillAndTestament_ContentType_Should_Allow_0_To_65535_Characters()
+    {
+        var contentType = GenerateUtf8String(65535);
+        var lwt = new LastWillAndTestamentBuilder()
+                .WithTopic("last/will")
+                .WithPayload("last will message")
+                .WithQualityOfServiceLevel(QualityOfService.AtLeastOnceDelivery)
+                .WithContentType(contentType)
+                .Build();
+
+        var options = new HiveMQClientOptionsBuilder()
+                    .WithLastWillAndTestament(lwt)
+                    .Build();
+
+        var client = new HiveMQClient(options);
+
+        client.Should().NotBeNull();
+    }
+
+    // [Test]
+    // public void ReasonString_Should_Allow_0_To_65535_Characters()
+    // {
+    //     var reasonString = GenerateUtf8String(65535);
+    //     var options = new HiveMQClientOptionsBuilder()
+    //                   .WithReasonString(reasonString)
+    //                   .Build();
+    //     var client = new Client.HiveMQClient(options);
+
+    //     client.Should().NotBeNull();
+    // }
+
+    [Test]
+    public void AuthenticationMethod_Should_Allow_0_To_65535_Characters()
+    {
+        var authMethod = GenerateUtf8String(65535);
+        var options = new HiveMQClientOptionsBuilder()
+                        .WithAuthenticationMethod(authMethod)
+                        .Build();
+        var client = new HiveMQClient(options);
+
+        client.Should().NotBeNull();
+    }
+
+    private static string GenerateUtf8String(int length) => new string('a', length);
+
+}

--- a/Tests/HiveMQtt.Test/HiveMQtt.Test.csproj
+++ b/Tests/HiveMQtt.Test/HiveMQtt.Test.csproj
@@ -28,4 +28,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Description

In the ramp up to v1, we are putting in thorough E2E tests to cover all parts of the protocol and client.

Besides extended tests, this PR includes the following fixes:

1. Fix `DecodeUTF8String` to properly handle response strings up to 65535 in length
2. Add `DisconnectOptionsBuilder` and support all options for MQTT v5 `Disconnect`
3. More limits checking on things such as Client ID length and other passed in options.

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
