### PR TITLE
ConnectOptions & v1.0 Test Plan Updates

### DIFF
--- a/Documentation/docs/reference/connect_options.md
+++ b/Documentation/docs/reference/connect_options.md
@@ -1,0 +1,35 @@
+# ConnectOptions
+
+The `ConnectOptions` class provides options for a connect call made with `ConnectAsync`. These options can override settings that were originally set in `HiveMQClientOptions`.
+
+## Constructors
+
+* `ConnectOptions()`: Initializes a new instance of the `ConnectOptions` class with defaults.
+
+## Properties
+
+* `SessionExpiryInterval`: Gets or sets the session expiry interval in seconds. This overrides any value set in HiveMQClientOptions.
+    + Example: `SessionExpiryInterval = 3600` sets the session to expire in 1 hour.
+
+* `KeepAlive`: Gets or sets the keep alive period in seconds. This overrides any value set in HiveMQClientOptions.
+    + Example: `KeepAlive = 60` sets the keep alive to 60 seconds.
+
+* `CleanStart`: Gets or sets whether to use a clean start. This overrides any value set in HiveMQClientOptions.
+    + Example: `CleanStart = true` starts a new session, discarding any existing session.
+
+## Examples
+
+```csharp
+ConnectOptions connectOptions = new ConnectOptions();
+connectOptions.SessionExpiryInterval = 3600;  // 1 hour session expiry
+connectOptions.KeepAlive = 60;                // 60 second keep alive
+connectOptions.CleanStart = true;             // Start with a clean session
+
+await client.ConnectAsync(connectOptions);
+```
+
+## See Also
+
+* [HiveMQClientOptions Reference](/docs/reference/client_options)
+* [Connecting to an MQTT Broker](/docs/connecting)
+* [Session Handling](/docs/how-to/session-handling) 

--- a/Documentation/docs/reference/connect_options_builder.md
+++ b/Documentation/docs/reference/connect_options_builder.md
@@ -1,0 +1,68 @@
+# ConnectOptionsBuilder
+
+The `ConnectOptionsBuilder` class is a builder pattern implementation that provides a convenient way to construct `ConnectOptions` objects for configuring connect behavior in HiveMQtt client applications.
+
+## Methods
+
+### `WithSessionExpiryInterval(long sessionExpiryInterval)`
+
+Sets the session expiry interval for the connection.
+
+- **Description:** Specifies the duration, in seconds, for which the session state will be maintained by the broker. This overrides any value set in HiveMQClientOptions.
+- **Example:** 
+  ```csharp
+  .WithSessionExpiryInterval(3600) // 1 hour session expiry
+  ```
+
+### `WithKeepAlive(int keepAlive)`
+
+Sets the keep alive period for the connection.
+
+- **Description:** Specifies the maximum time interval that is permitted to elapse between the point at which the Client finishes transmitting one Control Packet and the point it starts sending the next. This overrides any value set in HiveMQClientOptions.
+- **Example:** 
+  ```csharp
+  .WithKeepAlive(60) // 60 second keep alive
+  ```
+
+### `WithCleanStart(bool cleanStart)`
+
+Sets whether to use a clean start for the connection.
+
+- **Description:** Specifies whether the Connection starts a new Session or is a continuation of an existing Session. This overrides any value set in HiveMQClientOptions.
+- **Example:** 
+  ```csharp
+  .WithCleanStart(true) // Start with a clean session
+  ```
+
+### `Build()`
+
+Builds the ConnectOptions instance.
+
+- **Description:** Creates and returns a new ConnectOptions object with all the configured settings.
+- **Example:**
+  ```csharp
+  ConnectOptions options = new ConnectOptionsBuilder()
+      .WithSessionExpiryInterval(3600)
+      .WithKeepAlive(60)
+      .WithCleanStart(true)
+      .Build();
+  ```
+
+## Complete Example
+
+```csharp
+var connectOptions = new ConnectOptionsBuilder()
+    .WithSessionExpiryInterval(3600)  // 1 hour session expiry
+    .WithKeepAlive(60)               // 60 second keep alive
+    .WithCleanStart(true)            // Start with a clean session
+    .Build();
+
+await client.ConnectAsync(connectOptions);
+```
+
+## See Also
+
+* [ConnectOptions Reference](/docs/reference/connect_options)
+* [HiveMQClientOptions Reference](/docs/reference/client_options)
+* [Connecting to an MQTT Broker](/docs/connecting)
+* [Session Handling](/docs/how-to/session-handling) 

--- a/Source/HiveMQtt/Client/ConnectOptionsbuilder.cs
+++ b/Source/HiveMQtt/Client/ConnectOptionsbuilder.cs
@@ -22,8 +22,7 @@ using HiveMQtt.Client.Options;
 /// </summary>
 public class ConnectOptionsBuilder
 {
-    private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
-
+    // private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
     private readonly ConnectOptions options;
 
     public ConnectOptionsBuilder() => this.options = new ConnectOptions();

--- a/Source/HiveMQtt/Client/ConnectOptionsbuilder.cs
+++ b/Source/HiveMQtt/Client/ConnectOptionsbuilder.cs
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2025-present HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace HiveMQtt.Client;
+
+using HiveMQtt.Client.Options;
+
+/// <summary>
+/// Builder class for the ConnectOptions class.
+/// </summary>
+public class ConnectOptionsBuilder
+{
+    private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+
+    private readonly ConnectOptions options;
+
+    public ConnectOptionsBuilder() => this.options = new ConnectOptions();
+
+    /// <summary>
+    /// Sets the session expiry interval for the connect options.
+    /// </summary>
+    /// <param name="sessionExpiryInterval">The session expiry interval in seconds.</param>
+    /// <returns>The ConnectOptionsBuilder instance.</returns>
+    public ConnectOptionsBuilder WithSessionExpiryInterval(long sessionExpiryInterval)
+    {
+        this.options.SessionExpiryInterval = sessionExpiryInterval;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the keep alive for the connect options.
+    /// </summary>
+    /// <param name="keepAlive">The keep alive in seconds.</param>
+    /// <returns>The ConnectOptionsBuilder instance.</returns>
+    public ConnectOptionsBuilder WithKeepAlive(int keepAlive)
+    {
+        this.options.KeepAlive = keepAlive;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the clean start for the connect options.
+    /// </summary>
+    /// <param name="cleanStart">The clean start flag.</param>
+    /// <returns>The ConnectOptionsBuilder instance.</returns>
+    public ConnectOptionsBuilder WithCleanStart(bool cleanStart)
+    {
+        this.options.CleanStart = cleanStart;
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the ConnectOptions instance.
+    /// </summary>
+    /// <returns>The ConnectOptions instance.</returns>
+    public ConnectOptions Build() => this.options;
+}

--- a/Source/HiveMQtt/Client/HiveMQClient.cs
+++ b/Source/HiveMQtt/Client/HiveMQClient.cs
@@ -70,11 +70,30 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
     public bool IsConnected() => this.Connection.State == ConnectState.Connected;
 
     /// <inheritdoc />
-    public async Task<ConnectResult> ConnectAsync()
+    public async Task<ConnectResult> ConnectAsync(ConnectOptions? connectOptions = null)
     {
         this.Connection.State = ConnectState.Connecting;
 
         Logger.Info("Connecting to broker at {0}:{1}", this.Options.Host, this.Options.Port);
+
+        // Apply the connect override options if provided
+        if (connectOptions != null)
+        {
+            if (connectOptions.SessionExpiryInterval != null)
+            {
+                this.Options.SessionExpiryInterval = connectOptions.SessionExpiryInterval.Value;
+            }
+
+            if (connectOptions.KeepAlive != null)
+            {
+                this.Options.KeepAlive = connectOptions.KeepAlive.Value;
+            }
+
+            if (connectOptions.CleanStart != null)
+            {
+                this.Options.CleanStart = connectOptions.CleanStart.Value;
+            }
+        }
 
         // Fire the corresponding event
         this.BeforeConnectEventLauncher(this.Options);

--- a/Source/HiveMQtt/Client/HiveMQClient.cs
+++ b/Source/HiveMQtt/Client/HiveMQClient.cs
@@ -193,6 +193,13 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
     {
         message.Validate();
 
+        if (message.QoS.HasValue && this.Connection.ConnectionProperties.MaximumQoS.HasValue &&
+            (ushort)message.QoS.Value > this.Connection.ConnectionProperties.MaximumQoS.Value)
+        {
+            Logger.Debug($"Reducing message QoS from {message.QoS} to broker enforced maximum of {this.Connection.ConnectionProperties.MaximumQoS}");
+            message.QoS = (QualityOfService)this.Connection.ConnectionProperties.MaximumQoS.Value;
+        }
+
         // QoS 0: Fast Service
         if (message.QoS == QualityOfService.AtMostOnceDelivery)
         {

--- a/Source/HiveMQtt/Client/IHiveMQClient.cs
+++ b/Source/HiveMQtt/Client/IHiveMQClient.cs
@@ -58,15 +58,17 @@ public interface IHiveMQClient : IDisposable
     /// Asynchronously makes a TCP connection to the remote specified in HiveMQClientOptions and then
     /// proceeds to make an MQTT Connect request.
     /// </summary>
+    /// <param name="connectOptions">The connect override options for the MQTT Connect call.  These settings
+    /// will override the settings in HiveMQClientOptions.</param>
     /// <returns>A ConnectResult class representing the result of the MQTT connect call.</returns>
-    public Task<ConnectResult> ConnectAsync();
+    public Task<ConnectResult> ConnectAsync(ConnectOptions? connectOptions);
 
     /// <summary>
     /// Asynchronous disconnect from the previously connected MQTT broker.
     /// </summary>
     /// <param name="options">The options for the MQTT Disconnect call.</param>
     /// <returns>A boolean indicating on success or failure.</returns>
-    public Task<bool> DisconnectAsync(DisconnectOptions options);
+    public Task<bool> DisconnectAsync(DisconnectOptions? options);
 
     /// <summary>
     /// Publish a message to an MQTT topic.

--- a/Source/HiveMQtt/Client/Options/ConnectOptions.cs
+++ b/Source/HiveMQtt/Client/Options/ConnectOptions.cs
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025-present HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace HiveMQtt.Client.Options;
+
+/// <summary>
+/// The options class for a Connect call.  The settings here can override the settings that may have
+/// been set in the HiveMQClientOptions.
+/// </summary>
+public class ConnectOptions
+{
+    public long? SessionExpiryInterval { get; set; }
+
+    public int? KeepAlive { get; set; }
+
+    public bool? CleanStart { get; set; }
+}

--- a/Source/HiveMQtt/Client/Transport/WebSocketTransport.cs
+++ b/Source/HiveMQtt/Client/Transport/WebSocketTransport.cs
@@ -117,9 +117,7 @@ public class WebSocketTransport : BaseTransport, IDisposable
             do
             {
                 result = await this.Socket.ReceiveAsync(buffer, CancellationToken.None).ConfigureAwait(false);
-#pragma warning disable CA1835 // Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
-                await ms.WriteAsync(buffer.Array, buffer.Offset, result.Count, cancellationToken).ConfigureAwait(false);
-#pragma warning restore CA1835 // Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+                await ms.WriteAsync(buffer.AsMemory(buffer.Offset, result.Count), cancellationToken).ConfigureAwait(false);
             }
             while (!result.EndOfMessage);
 

--- a/Source/HiveMQtt/Client/internal/BoundedDictionaryX.cs
+++ b/Source/HiveMQtt/Client/internal/BoundedDictionaryX.cs
@@ -168,7 +168,12 @@ public class BoundedDictionaryX<TKey, TVal> : IDisposable
         {
             var numItems = this.dictionary.Count;
             this.dictionary.Clear();
-            this.semaphore.Release(numItems);
+
+            if (numItems > 0)
+            {
+                this.semaphore.Release(numItems);
+            }
+
             return true;
         }
         catch (ArgumentNullException ex)

--- a/Source/HiveMQtt/Client/internal/Validator.cs
+++ b/Source/HiveMQtt/Client/internal/Validator.cs
@@ -40,6 +40,7 @@ public class Validator
         }
 
         // Regular expression to match any character that is NOT in the specified set
+        // We can't use GeneratedRegexAttribute because it's not available in .net 6.0
         var regex = new Regex("[^0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ]");
 
         // Check if the input string contains any character that does not match the pattern

--- a/Source/HiveMQtt/MQTT5/Types/MQTT5PublishMessage.cs
+++ b/Source/HiveMQtt/MQTT5/Types/MQTT5PublishMessage.cs
@@ -173,6 +173,11 @@ public class MQTT5PublishMessage
             this.PayloadFormatIndicator = MQTT5PayloadFormatIndicator.Unspecified;
         }
 
+        if (!this.QoS.HasValue)
+        {
+            this.QoS = QualityOfService.AtMostOnceDelivery;
+        }
+
         if (this.MessageExpiryInterval.HasValue && (this.MessageExpiryInterval.Value is < 0 or > 268435455))
         {
             throw new HiveMQttClientException("Message Expiry Interval must be between 0 and 268_435_455.");

--- a/Tests/HiveMQtt.Test/HiveMQClient/ConnectTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/ConnectTest.cs
@@ -40,7 +40,7 @@ public class ConnectTest
         var clientOptions = new HiveMQClientOptionsBuilder().WithPort(0).WithClientId("RaiseOnFailureToConnectAsync").Build();
         var client = new HiveMQClient(clientOptions);
 
-        await Assert.ThrowsAsync<HiveMQttClientException>(client.ConnectAsync).ConfigureAwait(false);
+        await Assert.ThrowsAsync<HiveMQttClientException>(() => client.ConnectAsync()).ConfigureAwait(false);
 
         client.Dispose();
     }

--- a/Tests/HiveMQtt.Test/HiveMQClient/Plan/PacketRestrictionsTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/Plan/PacketRestrictionsTest.cs
@@ -7,6 +7,7 @@ using NUnit.Framework;
 using System;
 using System.Threading.Tasks;
 using HiveMQtt.Client.Exceptions;
+using HiveMQtt.MQTT5.ReasonCodes;
 
 [TestFixture]
 public class PacketRestrictionsTest
@@ -36,7 +37,7 @@ public class PacketRestrictionsTest
         connectResult.Should().NotBeNull();
 
         var unsubscribeOptions = new UnsubscribeOptionsBuilder()
-                                    .WithSubscription(new Subscription("nonexistent/topic"))
+                                    .WithSubscription(new Subscription("nonexistent/topic129482"))
                                     .Build();
 
         // Act
@@ -44,8 +45,12 @@ public class PacketRestrictionsTest
 
         // Assert
         result.Should().NotBeNull();
-        // result.ReasonCodes.Should().Contain(ReasonCode.NoSubscriptionExisted);
-        // result.Subscriptions.Count.Should().Be(1);
+        result.Subscriptions.Count.Should().Be(1);
+
+        // HiveMQ broker returns success for unsubscribe with non-existent topic
+        // result.Subscriptions[0].UnsubscribeReasonCode.Should().Be(UnsubAckReasonCode.NoSubscriptionExisted);
+        result.Subscriptions[0].UnsubscribeReasonCode.Should().Be(UnsubAckReasonCode.Success);
+
         var disconnectResult = await client.DisconnectAsync().ConfigureAwait(false);
         disconnectResult.Should().BeTrue();
     }

--- a/Tests/HiveMQtt.Test/HiveMQClient/Plan/SessionExpiryTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/Plan/SessionExpiryTest.cs
@@ -31,10 +31,11 @@ public class SessionExpiryTest
         subscribeResult.Subscriptions[0].TopicFilter.Topic.Should().Be("test/topic");
         subscribeResult.Subscriptions[0].SubscribeReasonCode.Should().Be(SubAckReasonCode.GrantedQoS1);
 
-        // Normal disconnect and reconnect.  We should get session present
+        // Normal disconnect
         var disconnectResult = await client.DisconnectAsync().ConfigureAwait(false);
         disconnectResult.Should().BeTrue();
 
+        // Reconnect.  We should get session present
         var connectOptions = new ConnectOptionsBuilder().WithCleanStart(false).Build();
         var connectResult2 = await client.ConnectAsync(connectOptions).ConfigureAwait(false);
         connectResult2.Should().NotBeNull();
@@ -42,14 +43,16 @@ public class SessionExpiryTest
         connectResult2.SessionExpiryInterval.Should().Be(30);
         connectResult2.SessionPresent.Should().BeTrue();
 
-        // Disconnect with custom session expiry, delay longer than the session expiry and reconnect.  We should get session not present
+        // Disconnect with custom session expiry
         var disconnectOptions = new DisconnectOptionsBuilder().WithSessionExpiryInterval(5).Build();
         disconnectResult = await client.DisconnectAsync(disconnectOptions).ConfigureAwait(false);
         disconnectResult.Should().BeTrue();
 
+        // Delay longer than the session expiry
         await Task.Delay(10000).ConfigureAwait(false);
 
-        var connectResult3 = await client.ConnectAsync().ConfigureAwait(false);
+        // Reconnect.  We should get session not present
+        var connectResult3 = await client.ConnectAsync(connectOptions).ConfigureAwait(false);
         connectResult3.Should().NotBeNull();
         connectResult3.ReasonCode.Should().Be(ConnAckReasonCode.Success);
         connectResult3.SessionExpiryInterval.Should().Be(30);

--- a/Tests/HiveMQtt.Test/HiveMQClient/Plan/SessionExpiryTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/Plan/SessionExpiryTest.cs
@@ -1,0 +1,58 @@
+namespace HiveMQtt.Test.HiveMQClient.Plan;
+
+using FluentAssertions;
+using HiveMQtt.Client;
+using HiveMQtt.MQTT5.ReasonCodes;
+using HiveMQtt.MQTT5.Types;
+using NUnit.Framework;
+using System.Threading.Tasks;
+
+[TestFixture]
+public class SessionExpiryTest
+{
+    [Test]
+    public async Task Disconnect_With_Custom_Session_Expiry_Async()
+    {
+        var options = new HiveMQClientOptionsBuilder()
+                        .WithSessionExpiryInterval(30)
+                        .Build();
+        var client = new HiveMQClient(options);
+
+        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+        connectResult.Should().NotBeNull();
+        connectResult.ReasonCode.Should().Be(ConnAckReasonCode.Success);
+        connectResult.SessionExpiryInterval.Should().Be(30);
+        connectResult.SessionPresent.Should().BeFalse();
+
+        // Subscribe to a topic
+        var subscribeResult = await client.SubscribeAsync(new SubscribeOptionsBuilder().WithSubscription("test/topic", QualityOfService.AtLeastOnceDelivery).Build()).ConfigureAwait(false);
+        subscribeResult.Should().NotBeNull();
+        subscribeResult.Subscriptions.Should().HaveCount(1);
+        subscribeResult.Subscriptions[0].TopicFilter.Topic.Should().Be("test/topic");
+        subscribeResult.Subscriptions[0].SubscribeReasonCode.Should().Be(SubAckReasonCode.GrantedQoS1);
+
+        // Normal disconnect and reconnect.  We should get session present
+        var disconnectResult = await client.DisconnectAsync().ConfigureAwait(false);
+        disconnectResult.Should().BeTrue();
+
+        var connectOptions = new ConnectOptionsBuilder().WithCleanStart(false).Build();
+        var connectResult2 = await client.ConnectAsync(connectOptions).ConfigureAwait(false);
+        connectResult2.Should().NotBeNull();
+        connectResult2.ReasonCode.Should().Be(ConnAckReasonCode.Success);
+        connectResult2.SessionExpiryInterval.Should().Be(30);
+        connectResult2.SessionPresent.Should().BeTrue();
+
+        // Disconnect with custom session expiry, delay longer than the session expiry and reconnect.  We should get session not present
+        var disconnectOptions = new DisconnectOptionsBuilder().WithSessionExpiryInterval(5).Build();
+        disconnectResult = await client.DisconnectAsync(disconnectOptions).ConfigureAwait(false);
+        disconnectResult.Should().BeTrue();
+
+        await Task.Delay(10000).ConfigureAwait(false);
+
+        var connectResult3 = await client.ConnectAsync().ConfigureAwait(false);
+        connectResult3.Should().NotBeNull();
+        connectResult3.ReasonCode.Should().Be(ConnAckReasonCode.Success);
+        connectResult3.SessionExpiryInterval.Should().Be(30);
+        connectResult3.SessionPresent.Should().BeFalse();
+    }
+}

--- a/Tests/HiveMQtt.Test/HiveMQClient/PublishTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/PublishTest.cs
@@ -514,4 +514,23 @@ public class PublishTest
         client2.Dispose();
         client3.Dispose();
     }
+
+    [Fact]
+    public async Task PublishWithoutQoSAsync()
+    {
+        var options = new HiveMQClientOptionsBuilder().WithClientId("PublishWithoutQoSAsync").Build();
+        var client = new HiveMQClient(options);
+        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+        Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
+
+        var msg = new string(/*lang=json,strict*/ "{\"interference\": \"1029384\"}");
+        var publishResult = await client.PublishAsync("tests/PublishWithoutQoSAsync", msg).ConfigureAwait(false);
+        Assert.NotNull(publishResult);
+        Assert.Equal(publishResult.Message.QoS, QualityOfService.AtMostOnceDelivery);
+
+        var disconnectResult = await client.DisconnectAsync().ConfigureAwait(false);
+        Assert.True(disconnectResult);
+
+        client.Dispose();
+    }
 }

--- a/Tests/HiveMQtt.Test/HiveMQClient/TLSTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/TLSTest.cs
@@ -1,28 +1,28 @@
-// namespace HiveMQtt.Test.HiveMQClient;
-//
-// using System.Threading.Tasks;
-// using HiveMQtt.Client;
-// using HiveMQtt.Client.Options;
-// using HiveMQtt.MQTT5.ReasonCodes;
-// using Xunit;
-//
-// public class TLSTest
-// {
-// #pragma warning disable xUnit1004
-//     [Fact(Skip = "Github CI failing: Need to be run manually")]
-// #pragma warning restore xUnit1004
-//     public async Task Public_Broker_TLS_Async()
-//     {
-//         var options = new HiveMQClientOptions
-//         {
-//             Host = "broker.hivemq.com",
-//             Port = 8883,
-//         };
-//
-//         var client = new HiveMQClient(options);
-//         var connectResult = await client.ConnectAsync().ConfigureAwait(false);
-//         Assert.Equal(ConnAckReasonCode.Success, connectResult.ReasonCode);
-//         var disconnectResult = await client.DisconnectAsync().ConfigureAwait(false);
-//         Assert.True(disconnectResult);
-//     }
-// }
+namespace HiveMQtt.Test.HiveMQClient;
+
+using System.Threading.Tasks;
+using HiveMQtt.Client;
+using HiveMQtt.Client.Options;
+using HiveMQtt.MQTT5.ReasonCodes;
+using Xunit;
+
+public class TLSTest
+{
+#pragma warning disable xUnit1004
+    [Fact(Skip = "Github CI failing: Need to be run manually")]
+#pragma warning restore xUnit1004
+    public async Task Public_Broker_TLS_Async()
+    {
+        var options = new HiveMQClientOptions
+        {
+            Host = "broker.hivemq.com",
+            Port = 8883,
+        };
+
+        var client = new HiveMQClient(options);
+        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+        Assert.Equal(ConnAckReasonCode.Success, connectResult.ReasonCode);
+        var disconnectResult = await client.DisconnectAsync().ConfigureAwait(false);
+        Assert.True(disconnectResult);
+    }
+}

--- a/Tests/HiveMQtt.Test/HiveMQClient/WebSocket/ConnectTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/WebSocket/ConnectTest.cs
@@ -60,7 +60,7 @@ public class ConnectTest
                             .WithClientId("RaiseOnFailureToConnectAsync").Build();
         var client = new HiveMQClient(clientOptions);
 
-        await Assert.ThrowsAsync<HiveMQttClientException>(client.ConnectAsync).ConfigureAwait(false);
+        await Assert.ThrowsAsync<HiveMQttClientException>(() => client.ConnectAsync()).ConfigureAwait(false);
 
         client.Dispose();
     }


### PR DESCRIPTION
## Description

* New optional `ConnectOptions` class and related builder (and documentation)
* Reset in-flight/mid-transaction messages on connect when session present == false
* Lower QoS if outgoing publishes if it exceeds broker communicated max QoS
* Set default QoS if not specified in PublishAsync
* Other general improvements & tests in preparation for v1.0.


<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
