### PR TITLE
feat: made (dis)connect options nullable in interface

### DIFF
--- a/Source/HiveMQtt/Client/IHiveMQClient.cs
+++ b/Source/HiveMQtt/Client/IHiveMQClient.cs
@@ -61,14 +61,14 @@ public interface IHiveMQClient : IDisposable
     /// <param name="connectOptions">The connect override options for the MQTT Connect call.  These settings
     /// will override the settings in HiveMQClientOptions.</param>
     /// <returns>A ConnectResult class representing the result of the MQTT connect call.</returns>
-    public Task<ConnectResult> ConnectAsync(ConnectOptions? connectOptions);
+    public Task<ConnectResult> ConnectAsync(ConnectOptions? connectOptions = null);
 
     /// <summary>
     /// Asynchronous disconnect from the previously connected MQTT broker.
     /// </summary>
     /// <param name="options">The options for the MQTT Disconnect call.</param>
     /// <returns>A boolean indicating on success or failure.</returns>
-    public Task<bool> DisconnectAsync(DisconnectOptions? options);
+    public Task<bool> DisconnectAsync(DisconnectOptions? options = null);
 
     /// <summary>
     /// Publish a message to an MQTT topic.


### PR DESCRIPTION
## Description
Both `IHiveMQClient` and `HiveMQClient` support parameterless connect and disconnect.

## Related Issue
Closes #236
## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [X] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [X] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [X] I've added documentation as necessary so users can easily use and understand this feature/fix.
