### PR TITLE
fix: lock subscriptions

### DIFF
--- a/Source/HiveMQtt/Client/HiveMQClient.cs
+++ b/Source/HiveMQtt/Client/HiveMQClient.cs
@@ -545,7 +545,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         try
         {
             await this.SubscriptionsSemaphore.WaitAsync().ConfigureAwait(false);
-            currentSubscriptions = [.. this.Subscriptions];
+            currentSubscriptions = this.Subscriptions.ToHashSet();
         }
         finally
         {

--- a/Source/HiveMQtt/Client/HiveMQClientEvents.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientEvents.cs
@@ -278,7 +278,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         try
         {
             this.SubscriptionsSemaphore.Wait();
-            tempList = [.. this.Subscriptions];
+            tempList = this.Subscriptions.ToList();
         }
         finally
         {

--- a/Source/HiveMQtt/Client/HiveMQClientEvents.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientEvents.cs
@@ -266,26 +266,46 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
             messageHandled = true;
         }
 
-        // Per Subscription Event Handler
-        foreach (var subscription in this.Subscriptions)
+        if (packet.Message.Topic is null)
         {
-            if (packet.Message.Topic != null && MatchTopic(subscription.TopicFilter.Topic, packet.Message.Topic))
-            {
-                if (subscription.MessageReceivedHandler != null && subscription.MessageReceivedHandler.GetInvocationList().Length > 0)
-                {
-                    // We have a per-subscription message handler.
-                    _ = Task.Run(() => subscription.MessageReceivedHandler?.Invoke(this, eventArgs)).ContinueWith(
-                        t =>
-                        {
-                            if (t.IsFaulted)
-                            {
-                                Logger.Error($"per-subscription MessageReceivedEventLauncher faulted ({packet.Message.Topic}): {t.Exception?.Message}");
-                            }
-                        }, TaskScheduler.Default);
+            return;
+        }
 
-                    messageHandled = true;
+        // Per Subscription Event Handler
+        // use ToList, so the iteration goes through a copy and changes at the list make not problems
+        // otherwise it would be necessary to lock the Subscriptions with the semaphore of HiveMQClient
+        List<Subscription> tempList;
+        try
+        {
+            this.SubscriptionsSemaphore.Wait();
+            tempList = [.. this.Subscriptions];
+        }
+        finally
+        {
+            _ = this.SubscriptionsSemaphore.Release();
+        }
+
+        var matchingSubscriptions = tempList.Where(sub =>
+            sub.MessageReceivedHandler is not null &&
+            MatchTopic(sub.TopicFilter.Topic, packet.Message.Topic));
+
+        foreach (var subscription in matchingSubscriptions)
+        {
+            // We have a per-subscription message handler.
+            _ = Task.Run(() =>
+            {
+                try
+                {
+                    subscription.MessageReceivedHandler?.Invoke(this, eventArgs);
                 }
-            }
+                catch (Exception e)
+                {
+                    Logger.Error(
+                        $"per-subscription MessageReceivedEventLauncher faulted ({packet.Message.Topic}): {e.Message}");
+                }
+            });
+
+            messageHandled = true;
         }
 
         if (!messageHandled)

--- a/Source/HiveMQtt/Client/HiveMQClientUtil.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientUtil.cs
@@ -35,7 +35,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         try
         {
             this.SubscriptionsSemaphore.Wait();
-            tempList = [.. this.Subscriptions];
+            tempList = this.Subscriptions.ToList();
         }
         finally
         {
@@ -56,7 +56,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         try
         {
             this.SubscriptionsSemaphore.Wait();
-            tempList = [.. this.Subscriptions];
+            tempList = this.Subscriptions.ToList();
         }
         finally
         {

--- a/Source/HiveMQtt/Client/HiveMQClientUtil.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientUtil.cs
@@ -31,20 +31,18 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
     /// <returns>A boolean indicating whether the subscription exists.</returns>
     internal bool SubscriptionExists(Subscription subscription)
     {
-        if (this.Subscriptions.Contains(subscription))
+        List<Subscription> tempList;
+        try
         {
-            return true;
+            this.SubscriptionsSemaphore.Wait();
+            tempList = [.. this.Subscriptions];
+        }
+        finally
+        {
+            _ = this.SubscriptionsSemaphore.Release();
         }
 
-        foreach (var candidate in this.Subscriptions)
-        {
-            if (candidate.TopicFilter.Topic == subscription.TopicFilter.Topic)
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return tempList.Any(s => s.TopicFilter.Topic == subscription.TopicFilter.Topic);
     }
 
     /// <summary>
@@ -54,15 +52,18 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
     /// <returns>The subscription or null if not found.</returns>
     internal Subscription? GetSubscriptionByTopic(string topic)
     {
-        foreach (var subscription in this.Subscriptions)
+        List<Subscription> tempList;
+        try
         {
-            if (subscription.TopicFilter.Topic == topic)
-            {
-                return subscription;
-            }
+            this.SubscriptionsSemaphore.Wait();
+            tempList = [.. this.Subscriptions];
+        }
+        finally
+        {
+            _ = this.SubscriptionsSemaphore.Release();
         }
 
-        return null;
+        return tempList.FirstOrDefault(s => s.TopicFilter.Topic == topic);
     }
 
     /// <summary>

--- a/Tests/HiveMQtt.Test/HiveMQClient/ThreadSafeSubscribeUnsubscribeTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/ThreadSafeSubscribeUnsubscribeTest.cs
@@ -1,0 +1,87 @@
+﻿namespace HiveMQtt.Test.HiveMQClient;
+
+using System.Collections.Concurrent;
+using Client;
+using Client.Options;
+using MQTT5.ReasonCodes;
+using MQTT5.Types;
+using Xunit;
+using Xunit.Abstractions;
+
+public class ThreadSafeSubscribeUnsubscribeTest(ITestOutputHelper testOutputHelper)
+{
+    [Fact]
+    public async Task SubscribeUnsubscribe_InManyThreadsAsync()
+    {
+        const int workerCount = 100;
+        const int iterationsPerWorker = 100;
+        const int topicsPerIteration = 10;
+        const int publishesPerIteration = 10;
+        const int totalExpectedSuccesses = workerCount * iterationsPerWorker;
+
+        var options = new HiveMQClientOptionsBuilder().WithClientId("ConcurrentSubscribeUnsubscribeAndPublish").Build();
+        options.ResponseTimeoutInMs = 20000;
+        var client = new HiveMQClient(options);
+        Assert.NotNull(client);
+
+        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+        Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
+        Assert.True(client.IsConnected());
+
+        client.OnMessageReceived += (_, args) => { };
+        _ = await client.SubscribeAsync("/test/#").ConfigureAwait(false);
+
+        ConcurrentBag<string> exceptionMessages = [];
+        var successCount = 0;
+        var tasks = new List<Task>();
+
+        foreach (var workerId in Enumerable.Range(0, workerCount))
+        {
+            tasks.Add(Task.Run(async () =>
+            {
+                for (var i = 0; i < iterationsPerWorker; i++)
+                {
+                    var topicPrefix = $"/test/topic/{workerId}/{i}";
+
+                    var topicsToManage = Enumerable.Range(0, topicsPerIteration)
+                                                   .Select(j => $"{topicPrefix}/{(char)('a' + j)}")
+                                                   .ToList();
+
+                    try
+                    {
+                        var topicFilters = topicsToManage.Select(topic => new TopicFilter(topic, QualityOfService.ExactlyOnceDelivery)).ToList();
+                        var subscribeOptions = new SubscribeOptions { TopicFilters = topicFilters };
+                        _ = await client.SubscribeAsync(subscribeOptions).ConfigureAwait(false);
+
+                        var publishTasks = new List<Task>(publishesPerIteration * 3);
+                        for (var j = 0; j < publishesPerIteration; j++)
+                        {
+                            publishTasks.Add(client.PublishAsync(topicsToManage.First(), "Hello World"));
+                            publishTasks.Add(client.PublishAsync(topicsToManage.Last(), "Hello World"));
+                            publishTasks.Add(client.PublishAsync("/unknown/topic", "Hello World"));
+                        }
+
+                        await Task.WhenAll(publishTasks).ConfigureAwait(false);
+
+                        var subscriptions = topicsToManage.Select(topic => new Subscription(new TopicFilter(topic))).ToList();
+                        var unsubscribeOptions = new UnsubscribeOptions { Subscriptions = subscriptions };
+                        _ = await client.UnsubscribeAsync(unsubscribeOptions).ConfigureAwait(false);
+
+                        _ = Interlocked.Increment(ref successCount);
+                    }
+                    catch (Exception e)
+                    {
+                        var errorMessage = $"Worker {workerId}, Iteration {i}: {e}";
+                        exceptionMessages.Add(errorMessage);
+                        testOutputHelper.WriteLine(errorMessage);
+                    }
+                }
+            }));
+        }
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+
+        Assert.Equal(totalExpectedSuccesses, successCount);
+        Assert.Empty(exceptionMessages);
+    }
+}

--- a/Tests/HiveMQtt.Test/HiveMQClient/ThreadSafeSubscribeUnsubscribeTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/ThreadSafeSubscribeUnsubscribeTest.cs
@@ -8,8 +8,15 @@ using MQTT5.Types;
 using Xunit;
 using Xunit.Abstractions;
 
-public class ThreadSafeSubscribeUnsubscribeTest(ITestOutputHelper testOutputHelper)
+public class ThreadSafeSubscribeUnsubscribeTest
 {
+    private readonly ITestOutputHelper testOutputHelper;
+
+    public ThreadSafeSubscribeUnsubscribeTest(ITestOutputHelper testOutputHelper)
+    {
+        this.testOutputHelper = testOutputHelper;
+    }
+
     [Fact]
     public async Task SubscribeUnsubscribe_InManyThreadsAsync()
     {

--- a/Tests/HiveMQtt.Test/HiveMQClient/ThreadSafeSubscribeUnsubscribeTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/ThreadSafeSubscribeUnsubscribeTest.cs
@@ -38,7 +38,7 @@ public class ThreadSafeSubscribeUnsubscribeTest
         client.OnMessageReceived += (_, args) => { };
         _ = await client.SubscribeAsync("/test/#").ConfigureAwait(false);
 
-        ConcurrentBag<string> exceptionMessages = [];
+        var exceptionMessages = new ConcurrentBag<string>();
         var successCount = 0;
         var tasks = new List<Task>();
 
@@ -80,7 +80,7 @@ public class ThreadSafeSubscribeUnsubscribeTest
                     {
                         var errorMessage = $"Worker {workerId}, Iteration {i}: {e}";
                         exceptionMessages.Add(errorMessage);
-                        testOutputHelper.WriteLine(errorMessage);
+                        this.testOutputHelper.WriteLine(errorMessage);
                     }
                 }
             }));


### PR DESCRIPTION
## Description

Every access of the Subscriptions property is now locked with a semaphore. User of the client should not access the Subscriptions, also this property is public, because they can not lock the access. Later the Subscriptions should not be public and be perhaps of type ConcurrentBag.

## Related Issue

https://github.com/hivemq/hivemq-mqtt-client-dotnet/issues/225

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [x] I've added documentation as necessary so users can easily use and understand this feature/fix.
