### PR TITLE
fix: ConnectionMonitor is stopped by cancellation token during discon…

### DIFF
--- a/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
@@ -129,7 +129,7 @@ public partial class ConnectionManager : IDisposable
         this.ConnectionWriterTask = this.ConnectionWriterAsync(this.cancellationTokenSource.Token);
         this.ConnectionReaderTask = this.ConnectionReaderAsync(this.cancellationTokenSource.Token);
         this.ReceivedPacketsHandlerTask = this.ReceivedPacketsHandlerAsync(this.cancellationTokenSource.Token);
-        this.ConnectionMonitorThread = this.LaunchConnectionMonitorThread();
+        this.ConnectionMonitorThread = this.LaunchConnectionMonitorThreadAsync(this.cancellationTokenSource.Token);
 
         return true;
     }
@@ -184,7 +184,7 @@ public partial class ConnectionManager : IDisposable
             Logger.Trace("ReceivedPacketsHandlerTask did not complete in time");
         }
 
-        if (this.ConnectionMonitorThread is not null && !this.ConnectionMonitorThread.IsAlive)
+        if (this.ConnectionMonitorThread is not null && this.ConnectionMonitorThread.IsCompleted)
         {
             this.ConnectionMonitorThread = null;
         }


### PR DESCRIPTION
## Description

Refactored `ConnectionMonitorThread` from a `Thread` to a `Task` to support proper async execution and cancellation. Updated related logic to use a `CancellationToken`, and replaced `Thread.Sleep` with `Task.Delay`. Updated tests accordingly and added a new test to verify that the connection monitor task stops correctly after disconnect.

This will stop the `ConnectionMonitorThread` from running forever after a disconnect. 

## Related Issue

#246 

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [x] I've added documentation as necessary so users can easily use and understand this feature/fix.
