### PR TITLE
Replace Delay with Connection Event Signal

### DIFF
--- a/Source/HiveMQtt/Client/Connection/ConnectionManagerHandlers.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManagerHandlers.cs
@@ -39,6 +39,7 @@ public partial class ConnectionManager
         }
 
         this.ConnectionProperties = connAckPacket.Properties;
+
         this.Client.OnConnAckReceivedEventLauncher(connAckPacket);
     }
 
@@ -386,6 +387,9 @@ public partial class ConnectionManager
 
         // Cancel all background tasks and close the socket
         this.State = ConnectState.Disconnected;
+
+        // Reset the connection-ready signal for the next connect cycle
+        this.ResetConnectedSignal();
 
         // Cancel all background tasks
         await this.CancelBackgroundTasksAsync().ConfigureAwait(false);

--- a/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
@@ -119,11 +119,11 @@ public partial class ConnectionManager
             {
                 try
                 {
-                    while (this.State != ConnectState.Connected)
+                    // Await connection readiness without polling to avoid arbitrary delay
+                    if (this.State != ConnectState.Connected)
                     {
                         Logger.Trace($"{this.Client.Options.ClientId}-(PW)- Not connected.  Waiting for connect...");
-                        await Task.Delay(500).ConfigureAwait(false);
-                        continue;
+                        await this.WaitUntilConnectedAsync(cancellationToken).ConfigureAwait(false);
                     }
 
                     var writeSuccess = true;

--- a/Source/HiveMQtt/Client/HiveMQClient.cs
+++ b/Source/HiveMQtt/Client/HiveMQClient.cs
@@ -134,6 +134,9 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         if (connAck.ReasonCode == ConnAckReasonCode.Success)
         {
             this.Connection.State = ConnectState.Connected;
+
+            // Ensure connection-ready signal is set for any writers awaiting readiness
+            this.Connection.SignalConnected();
         }
         else
         {


### PR DESCRIPTION
## Description

As reported in #217, we were using `Delay` to periodically check for connection.  This PR switches to an Event driven signal on client connection.

## Related Issue

#217

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
