### PR TITLE
Performance: Improve validation path and cached connection properties

### DIFF
--- a/Source/HiveMQtt/Client/Connection/ConnectionManagerHandlers.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManagerHandlers.cs
@@ -43,6 +43,9 @@ public partial class ConnectionManager
 
         this.ConnectionProperties = connAckPacket.Properties;
 
+        // Update cached connection properties for fast access during publish operations
+        this.Client.UpdateConnectionPropertyCache(connAckPacket.Properties);
+
         this.Client.OnConnAckReceivedEventLauncher(connAckPacket);
     }
 
@@ -403,6 +406,9 @@ public partial class ConnectionManager
         // This ensures tasks see the correct state when they check during cancellation
         this.State = ConnectState.Disconnected;
         this.ResetNotDisconnectedSignal();
+
+        // Clear cached connection properties since we're disconnected
+        this.Client.UpdateConnectionPropertyCache(null);
 
         if (clean)
         {

--- a/Source/HiveMQtt/MQTT5/Types/MQTT5PublishMessage.cs
+++ b/Source/HiveMQtt/MQTT5/Types/MQTT5PublishMessage.cs
@@ -35,8 +35,8 @@ public class MQTT5PublishMessage
         this.Duplicate = false;
         this.Retain = false;
         this.Topic = topic;
-        this.PayloadFormatIndicator = MQTT5PayloadFormatIndicator.Unspecified;
         this.QoS = qos ?? QualityOfService.AtMostOnceDelivery;
+        this.PayloadFormatIndicator = MQTT5PayloadFormatIndicator.Unspecified;
     }
 
     /// <summary>

--- a/Tests/HiveMQtt.Test/HiveMQClient/ClientTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/ClientTest.cs
@@ -3,6 +3,8 @@ namespace HiveMQtt.Test.HiveMQClient;
 using HiveMQtt.Client;
 using HiveMQtt.Client.Events;
 using HiveMQtt.Client.Internal;
+using HiveMQtt.MQTT5.ReasonCodes;
+using HiveMQtt.MQTT5.Types;
 using Xunit;
 
 public class ClientTest
@@ -35,7 +37,7 @@ public class ClientTest
         var connectResult = await client.ConnectAsync().ConfigureAwait(false);
 
         Assert.NotNull(connectResult);
-        Assert.True(connectResult.ReasonCode == MQTT5.ReasonCodes.ConnAckReasonCode.Success);
+        Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
 
         var result = await client.DisconnectAsync().ConfigureAwait(false);
 
@@ -73,7 +75,7 @@ public class ClientTest
         client.AfterConnect += AfterConnectHandler;
 
         var connectResult = await client.ConnectAsync().ConfigureAwait(false);
-        Assert.Equal(MQTT5.ReasonCodes.ConnAckReasonCode.Success, connectResult.ReasonCode);
+        Assert.Equal(ConnAckReasonCode.Success, connectResult.ReasonCode);
 
         try
         {
@@ -118,13 +120,13 @@ public class ClientTest
 
         var subResult = await client.SubscribeAsync(
                                         "tests/ClientTest",
-                                        MQTT5.Types.QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+                                        QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
 
         // Publish QoS 1 (At least once delivery)
         var pubResult = await client.PublishAsync(
                                         "tests/ClientTest",
                                         new string("♚ ♛ ♜ ♝ ♞ ♟ ♔ ♕ ♖ ♗ ♘ ♙"),
-                                        MQTT5.Types.QualityOfService.ExactlyOnceDelivery).ConfigureAwait(false);
+                                        QualityOfService.ExactlyOnceDelivery).ConfigureAwait(false);
 
         // Task Stuff
         Assert.NotNull(client.Connection.ConnectionWriterTask);

--- a/Tests/HiveMQtt.Test/HiveMQClient/Plan/BrokerEnforcementTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/Plan/BrokerEnforcementTest.cs
@@ -117,6 +117,9 @@ public class BrokerEnforcementTest
         // Manually override the connection properties to simulate a broker that does not support retained messages
         client.Connection.ConnectionProperties.RetainAvailable = false;
 
+        // Update cache to reflect the manual override
+        client.UpdateConnectionPropertyCache(client.Connection.ConnectionProperties);
+
         var message = new MQTT5PublishMessage
         {
             Topic = "test/topic",
@@ -162,6 +165,9 @@ public class BrokerEnforcementTest
 
         // Manually override the connection properties to simulate a broker that does not support retained messages
         client.Connection.ConnectionProperties.RetainAvailable = false;
+
+        // Update cache to reflect the manual override
+        client.UpdateConnectionPropertyCache(client.Connection.ConnectionProperties);
 
         var options = new SubscribeOptions();
         options.TopicFilters.Add(new TopicFilter("test/topic", retainAsPublished: true));
@@ -247,6 +253,9 @@ public class BrokerEnforcementTest
 
         // Manually override the connection properties to simulate a broker that does not support topic aliases
         client.Connection.ConnectionProperties.TopicAliasMaximum = 0;
+
+        // Update cache to reflect the manual override
+        client.UpdateConnectionPropertyCache(client.Connection.ConnectionProperties);
 
         var message = new MQTT5PublishMessage
         {

--- a/Tests/HiveMQtt.Test/HiveMQClient/SubscribeBuilderTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/SubscribeBuilderTest.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using HiveMQtt.Client;
 using HiveMQtt.Client.Events;
 using HiveMQtt.MQTT5.ReasonCodes;
+using HiveMQtt.MQTT5.Types;
 using Xunit;
 
 public class SubscribeBuilderTest
@@ -18,8 +19,8 @@ public class SubscribeBuilderTest
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
 
         var subscribeOptions = new SubscribeOptionsBuilder()
-            .WithSubscription("tests/MultiSubscribeAsync", MQTT5.Types.QualityOfService.AtLeastOnceDelivery)
-            .WithSubscription("tests/MultiSubscribeAsync2", MQTT5.Types.QualityOfService.AtLeastOnceDelivery)
+            .WithSubscription("tests/MultiSubscribeAsync", QualityOfService.AtLeastOnceDelivery)
+            .WithSubscription("tests/MultiSubscribeAsync2", QualityOfService.AtLeastOnceDelivery)
             .WithUserProperty("test", "test")
             .Build();
 
@@ -42,8 +43,8 @@ public class SubscribeBuilderTest
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
 
         var subscribeOptions = new SubscribeOptionsBuilder()
-            .WithSubscription("tests/MultiSubscribeAsync", MQTT5.Types.QualityOfService.AtLeastOnceDelivery, true, true, MQTT5.Types.RetainHandling.SendAtSubscribe)
-            .WithSubscription("tests/MultiSubscribeAsync2", MQTT5.Types.QualityOfService.AtLeastOnceDelivery)
+            .WithSubscription("tests/MultiSubscribeAsync", QualityOfService.AtLeastOnceDelivery, true, true, RetainHandling.SendAtSubscribe)
+            .WithSubscription("tests/MultiSubscribeAsync2", QualityOfService.AtLeastOnceDelivery)
             .WithUserProperty("test", "test")
             .Build();
 
@@ -53,7 +54,7 @@ public class SubscribeBuilderTest
         Assert.Equal(SubAckReasonCode.GrantedQoS1, subResult.Subscriptions[0].SubscribeReasonCode);
         Assert.Equal(true, subResult.Subscriptions[0].TopicFilter.NoLocal);
         Assert.Equal(true, subResult.Subscriptions[0].TopicFilter.RetainAsPublished);
-        Assert.Equal(MQTT5.Types.RetainHandling.SendAtSubscribe, subResult.Subscriptions[0].TopicFilter.RetainHandling);
+        Assert.Equal(RetainHandling.SendAtSubscribe, subResult.Subscriptions[0].TopicFilter.RetainHandling);
         Assert.Equal(SubAckReasonCode.GrantedQoS1, subResult.Subscriptions[1].SubscribeReasonCode);
 
         var disconnectResult = await subClient.DisconnectAsync().ConfigureAwait(false);
@@ -71,7 +72,7 @@ public class SubscribeBuilderTest
         var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
         var subscribeOptions = new SubscribeOptionsBuilder()
-            .WithSubscription("tests/PerSubscriptionHandler", MQTT5.Types.QualityOfService.AtLeastOnceDelivery, messageReceivedHandler: (sender, args) =>
+            .WithSubscription("tests/PerSubscriptionHandler", QualityOfService.AtLeastOnceDelivery, messageReceivedHandler: (sender, args) =>
             {
                 Assert.Equal("tests/PerSubscriptionHandler", args.PublishMessage.Topic);
                 Assert.Equal("test", args.PublishMessage.PayloadAsString);
@@ -117,7 +118,7 @@ public class SubscribeBuilderTest
 
         // Setup a per-subscription handler
         var subscribeOptions = new SubscribeOptionsBuilder()
-            .WithSubscription("tests/PerSubscriptionHandler", MQTT5.Types.QualityOfService.AtLeastOnceDelivery, messageReceivedHandler: (sender, args) =>
+            .WithSubscription("tests/PerSubscriptionHandler", QualityOfService.AtLeastOnceDelivery, messageReceivedHandler: (sender, args) =>
             {
                 Assert.Equal("tests/PerSubscriptionHandler", args.PublishMessage.Topic);
                 Assert.Equal("test", args.PublishMessage.PayloadAsString);
@@ -190,7 +191,7 @@ public class SubscribeBuilderTest
         var messageCount = 0;
 
         var subscribeOptions = new SubscribeOptionsBuilder()
-            .WithSubscription("tests/PerSubHandlerWithSingleLevelWildcard/+/msg", MQTT5.Types.QualityOfService.AtLeastOnceDelivery, messageReceivedHandler: (sender, args) =>
+            .WithSubscription("tests/PerSubHandlerWithSingleLevelWildcard/+/msg", QualityOfService.AtLeastOnceDelivery, messageReceivedHandler: (sender, args) =>
             {
                 var pattern = @"^tests/PerSubHandlerWithSingleLevelWildcard/[0-2]/msg$";
                 var regex = new Regex(pattern);
@@ -272,7 +273,7 @@ public class SubscribeBuilderTest
         var subscribeOptions = new SubscribeOptionsBuilder()
             .WithSubscription(
                 "tests/PerSubHandlerWithMultiLevelWildcard/#",
-                MQTT5.Types.QualityOfService.AtLeastOnceDelivery,
+                QualityOfService.AtLeastOnceDelivery,
                 messageReceivedHandler: (sender, args) =>
             {
                 var pattern = @"\Atests/PerSubHandlerWithMultiLevelWildcard/(/?|.+)\z";

--- a/Tests/HiveMQtt.Test/HiveMQClient/SubscribeTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/SubscribeTest.cs
@@ -37,8 +37,8 @@ public class SubscribeTest
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
 
         var subscribeOptions = new SubscribeOptions();
-        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync", MQTT5.Types.QualityOfService.AtLeastOnceDelivery));
-        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync2", MQTT5.Types.QualityOfService.AtLeastOnceDelivery));
+        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync", QualityOfService.AtLeastOnceDelivery));
+        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync2", QualityOfService.AtLeastOnceDelivery));
         subscribeOptions.UserProperties.Add("test", "test");
 
         var subResult = await subClient.SubscribeAsync(subscribeOptions).ConfigureAwait(false);
@@ -62,8 +62,8 @@ public class SubscribeTest
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
 
         var subscribeOptions = new SubscribeOptions();
-        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync", MQTT5.Types.QualityOfService.AtLeastOnceDelivery, true, true, MQTT5.Types.RetainHandling.SendAtSubscribe));
-        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync2", MQTT5.Types.QualityOfService.AtLeastOnceDelivery));
+        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync", QualityOfService.AtLeastOnceDelivery, true, true, RetainHandling.SendAtSubscribe));
+        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync2", QualityOfService.AtLeastOnceDelivery));
         subscribeOptions.UserProperties.Add("test", "test");
 
         var subResult = await subClient.SubscribeAsync(subscribeOptions).ConfigureAwait(false);
@@ -72,7 +72,7 @@ public class SubscribeTest
         Assert.Equal(SubAckReasonCode.GrantedQoS1, subResult.Subscriptions[0].SubscribeReasonCode);
         Assert.Equal(true, subResult.Subscriptions[0].TopicFilter.NoLocal);
         Assert.Equal(true, subResult.Subscriptions[0].TopicFilter.RetainAsPublished);
-        Assert.Equal(MQTT5.Types.RetainHandling.SendAtSubscribe, subResult.Subscriptions[0].TopicFilter.RetainHandling);
+        Assert.Equal(RetainHandling.SendAtSubscribe, subResult.Subscriptions[0].TopicFilter.RetainHandling);
         Assert.Equal(SubAckReasonCode.GrantedQoS1, subResult.Subscriptions[1].SubscribeReasonCode);
 
         var disconnectResult = await subClient.DisconnectAsync().ConfigureAwait(false);
@@ -87,7 +87,7 @@ public class SubscribeTest
         var connectResult = await subClient.ConnectAsync().ConfigureAwait(false);
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
 
-        var subResult = await subClient.SubscribeAsync("tests/SubscribeQoS1Async", MQTT5.Types.QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+        var subResult = await subClient.SubscribeAsync("tests/SubscribeQoS1Async", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
 
         Assert.NotEmpty(subResult.Subscriptions);
         Assert.Equal(SubAckReasonCode.GrantedQoS1, subResult.Subscriptions[0].SubscribeReasonCode);
@@ -104,7 +104,7 @@ public class SubscribeTest
         var connectResult = await subClient.ConnectAsync().ConfigureAwait(false);
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
 
-        var subResult = await subClient.SubscribeAsync("tests/SubscribeQoS2Async", MQTT5.Types.QualityOfService.ExactlyOnceDelivery).ConfigureAwait(false);
+        var subResult = await subClient.SubscribeAsync("tests/SubscribeQoS2Async", QualityOfService.ExactlyOnceDelivery).ConfigureAwait(false);
 
         Assert.NotEmpty(subResult.Subscriptions);
         Assert.Equal(SubAckReasonCode.GrantedQoS2, subResult.Subscriptions[0].SubscribeReasonCode);

--- a/Tests/HiveMQtt.Test/HiveMQClient/ThreadSafeSubscribeUnsubscribeTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/ThreadSafeSubscribeUnsubscribeTest.cs
@@ -1,10 +1,10 @@
 ﻿namespace HiveMQtt.Test.HiveMQClient;
 
 using System.Collections.Concurrent;
-using Client;
-using Client.Options;
-using MQTT5.ReasonCodes;
-using MQTT5.Types;
+using HiveMQtt.Client;
+using HiveMQtt.Client.Options;
+using HiveMQtt.MQTT5.ReasonCodes;
+using HiveMQtt.MQTT5.Types;
 using Xunit;
 using Xunit.Abstractions;
 

--- a/Tests/HiveMQtt.Test/HiveMQClient/WebSocket/SubscribeTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/WebSocket/SubscribeTest.cs
@@ -41,8 +41,8 @@ public class SubscribeTest
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
 
         var subscribeOptions = new SubscribeOptions();
-        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync", MQTT5.Types.QualityOfService.AtLeastOnceDelivery));
-        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync2", MQTT5.Types.QualityOfService.AtLeastOnceDelivery));
+        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync", QualityOfService.AtLeastOnceDelivery));
+        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync2", QualityOfService.AtLeastOnceDelivery));
         subscribeOptions.UserProperties.Add("test", "test");
 
         var subResult = await subClient.SubscribeAsync(subscribeOptions).ConfigureAwait(false);
@@ -68,8 +68,8 @@ public class SubscribeTest
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
 
         var subscribeOptions = new SubscribeOptions();
-        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync", MQTT5.Types.QualityOfService.AtLeastOnceDelivery, true, true, MQTT5.Types.RetainHandling.SendAtSubscribe));
-        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync2", MQTT5.Types.QualityOfService.AtLeastOnceDelivery));
+        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync", QualityOfService.AtLeastOnceDelivery, true, true, RetainHandling.SendAtSubscribe));
+        subscribeOptions.TopicFilters.Add(new TopicFilter("tests/MultiSubscribeAsync2", QualityOfService.AtLeastOnceDelivery));
         subscribeOptions.UserProperties.Add("test", "test");
 
         var subResult = await subClient.SubscribeAsync(subscribeOptions).ConfigureAwait(false);
@@ -95,7 +95,7 @@ public class SubscribeTest
         var connectResult = await subClient.ConnectAsync().ConfigureAwait(false);
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
 
-        var subResult = await subClient.SubscribeAsync("tests/SubscribeQoS1Async", MQTT5.Types.QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+        var subResult = await subClient.SubscribeAsync("tests/SubscribeQoS1Async", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
 
         Assert.NotEmpty(subResult.Subscriptions);
         Assert.Equal(SubAckReasonCode.GrantedQoS1, subResult.Subscriptions[0].SubscribeReasonCode);
@@ -114,7 +114,7 @@ public class SubscribeTest
         var connectResult = await subClient.ConnectAsync().ConfigureAwait(false);
         Assert.True(connectResult.ReasonCode == ConnAckReasonCode.Success);
 
-        var subResult = await subClient.SubscribeAsync("tests/SubscribeQoS2Async", MQTT5.Types.QualityOfService.ExactlyOnceDelivery).ConfigureAwait(false);
+        var subResult = await subClient.SubscribeAsync("tests/SubscribeQoS2Async", QualityOfService.ExactlyOnceDelivery).ConfigureAwait(false);
 
         Assert.NotEmpty(subResult.Subscriptions);
         Assert.Equal(SubAckReasonCode.GrantedQoS2, subResult.Subscriptions[0].SubscribeReasonCode);

--- a/Tests/HiveMQtt.Test/MQTT5/Types/MQTT5PublishMessageValidationTest.cs
+++ b/Tests/HiveMQtt.Test/MQTT5/Types/MQTT5PublishMessageValidationTest.cs
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2022-present HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace HiveMQtt.Test.MQTT5.Types;
+
+using HiveMQtt.Client.Exceptions;
+using HiveMQtt.MQTT5.Types;
+using Xunit;
+
+public class MQTT5PublishMessageValidationTest
+{
+    [Fact]
+    public void Validate_WhenTopicIsNullAndTopicAliasIsNull_ThrowsException()
+    {
+        // Arrange
+        var message = new MQTT5PublishMessage
+        {
+            Topic = null,
+            TopicAlias = null,
+        };
+
+        // Act & Assert
+        var exception = Assert.Throws<HiveMQttClientException>(message.Validate);
+        Assert.Equal("Either Topic or TopicAlias must be specified.", exception.Message);
+    }
+
+    [Fact]
+    public void Validate_WhenTopicIsNullAndTopicAliasHasValue_DoesNotThrow()
+    {
+        // Arrange
+        var message = new MQTT5PublishMessage
+        {
+            Topic = null,
+            TopicAlias = 1,
+        };
+
+        // Act
+        var exception = Record.Exception(message.Validate);
+
+        // Assert
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Validate_WhenTopicHasValueAndTopicAliasIsNull_DoesNotThrow()
+    {
+        // Arrange
+        var message = new MQTT5PublishMessage
+        {
+            Topic = "test/topic",
+            TopicAlias = null,
+        };
+
+        // Act
+        var exception = Record.Exception(message.Validate);
+
+        // Assert
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void Validate_WhenTopicHasValueAndTopicAliasHasValue_DoesNotThrow()
+    {
+        // Arrange
+        var message = new MQTT5PublishMessage
+        {
+            Topic = "test/topic",
+            TopicAlias = 1,
+        };
+
+        // Act
+        var exception = Record.Exception(message.Validate);
+
+        // Assert
+        Assert.Null(exception);
+    }
+}


### PR DESCRIPTION
## Description

- **Move most validations out of hot-path**
- **Use "null-coalescing assignment operator" (which is a real operator name)**
- **MQTT5PublishMessage: Move most validations out of publish hot code path**
- **Cached connection properties, fast path improvements & tests**

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've written tests (if applicable) for all new methods and classes that I created. (`rake test`)
- [ ] I've added documentation as necessary so users can easily use and understand this feature/fix.
