### PR TITLE
Fix Rebirth metric name to comply with Sparkplug B 3.0 spec

### DIFF
--- a/Documentation/docs/sparkplug/edge-node.md
+++ b/Documentation/docs/sparkplug/edge-node.md
@@ -45,12 +45,12 @@ await edgeNode.PublishNodeDataAsync(metrics);
 
 ## Rebirth Handling
 
-When a Host sends an NCMD with `Rebirth=true`, republish a fresh NBIRTH and related DBIRTH messages.
+When a Host sends an NCMD with `Node Control/Rebirth=true`, republish a fresh NBIRTH and related DBIRTH messages.
 
 ```csharp
 edgeNode.NodeCommandReceived += async (_, e) =>
 {
-    var isRebirth = e.Payload.Metrics.Any(m => m.Name == "Rebirth" && m.BooleanValue);
+    var isRebirth = e.Payload.Metrics.Any(m => m.Name == "Node Control/Rebirth" && m.BooleanValue);
     if (isRebirth)
     {
         await edgeNode.PublishNodeBirthAsync(null);

--- a/Documentation/docs/sparkplug/edge-node.md
+++ b/Documentation/docs/sparkplug/edge-node.md
@@ -50,7 +50,7 @@ When a Host sends an NCMD with `Node Control/Rebirth=true`, republish a fresh NB
 ```csharp
 edgeNode.NodeCommandReceived += async (_, e) =>
 {
-    var isRebirth = e.Payload.Metrics.Any(m => m.Name == "Node Control/Rebirth" && m.BooleanValue);
+    var isRebirth = e.Payload.Metrics.Any(m => m.Name == SparkplugPayloadEncoder.NodeControlRebirthMetricName && m.BooleanValue);
     if (isRebirth)
     {
         await edgeNode.PublishNodeBirthAsync(null);

--- a/Examples/SparkplugEdgeNode/Program.cs
+++ b/Examples/SparkplugEdgeNode/Program.cs
@@ -37,7 +37,7 @@ var edgeNode = new SparkplugEdgeNode(clientOptions, sparkplugOptions);
 edgeNode.NodeCommandReceived += async (_, e) =>
 {
     // Rebirth: Host requests a fresh NBIRTH so it receives current state. Re-publish node (and optionally device) births.
-    var isRebirth = e.Payload.Metrics.Any(m => m.Name == "Rebirth" && m.BooleanValue);
+    var isRebirth = e.Payload.Metrics.Any(m => m.Name == SparkplugPayloadEncoder.NodeControlRebirthMetricName && m.BooleanValue);
     if (isRebirth)
     {
         Console.WriteLine("[NCMD] Rebirth — publishing NBIRTH");

--- a/Examples/SparkplugEdgeNode/README.md
+++ b/Examples/SparkplugEdgeNode/README.md
@@ -1,6 +1,6 @@
 # Sparkplug Edge Node Example
 
-This example runs a **Sparkplug B Edge Node** using HiveMQtt.Sparkplug: it connects to an MQTT broker, publishes Node Birth (NBIRTH), subscribes to NCMD and DCMD, and publishes Node Data (NDATA) every 5 seconds with a counter and temperature metric. It handles the **Rebirth** command (NCMD with `Rebirth` metric): when received, it publishes a fresh NBIRTH. Press Q to stop (publishes NDEATH and disconnects).
+This example runs a **Sparkplug B Edge Node** using HiveMQtt.Sparkplug: it connects to an MQTT broker, publishes Node Birth (NBIRTH), subscribes to NCMD and DCMD, and publishes Node Data (NDATA) every 5 seconds with a counter and temperature metric. It handles the **Rebirth** command (NCMD with `Node Control/Rebirth` metric): when received, it publishes a fresh NBIRTH. Press Q to stop (publishes NDEATH and disconnects).
 
 ## Prerequisites
 

--- a/Source/HiveMQtt.Sparkplug/EdgeNode/SparkplugEdgeNode.cs
+++ b/Source/HiveMQtt.Sparkplug/EdgeNode/SparkplugEdgeNode.cs
@@ -199,6 +199,13 @@ public sealed class SparkplugEdgeNode : IDisposable
                 this.sequenceNumber = 0;
                 var birthPayload = SparkplugPayloadEncoder.CreatePayload(SparkplugPayloadEncoder.GetCurrentTimestamp(), 0);
                 birthPayload.Metrics.Insert(0, SparkplugPayloadEncoder.CreateBdSeqMetric(sessionBdSeq));
+
+                // Add the required Node Control/Rebirth metric per Sparkplug B 3.0 spec (tck-id-topics-nbirth-rebirth-metric)
+                birthPayload.Metrics.Add(
+                    SparkplugMetricBuilder.Create(SparkplugPayloadEncoder.NodeControlRebirthMetricName)
+                        .WithBooleanValue(false)
+                        .Build());
+
                 if (nodeBirthMetrics != null)
                 {
                     foreach (var m in nodeBirthMetrics)
@@ -310,6 +317,12 @@ public sealed class SparkplugEdgeNode : IDisposable
                 {
                     payload.Metrics.Insert(0, SparkplugPayloadEncoder.CreateBdSeqMetric(this.currentSessionBdSeq.Value));
                 }
+
+                // Add the required Node Control/Rebirth metric per Sparkplug B 3.0 spec (tck-id-topics-nbirth-rebirth-metric)
+                payload.Metrics.Add(
+                    SparkplugMetricBuilder.Create(SparkplugPayloadEncoder.NodeControlRebirthMetricName)
+                        .WithBooleanValue(false)
+                        .Build());
 
                 if (metrics != null)
                 {

--- a/Source/HiveMQtt.Sparkplug/HostApplication/SparkplugHostApplication.cs
+++ b/Source/HiveMQtt.Sparkplug/HostApplication/SparkplugHostApplication.cs
@@ -283,7 +283,7 @@ public sealed class SparkplugHostApplication : IDisposable
     public async Task<PublishResult> PublishRebirthCommandAsync(string groupId, string edgeNodeId, CancellationToken cancellationToken = default)
     {
         var payload = SparkplugPayloadEncoder.CreatePayload(SparkplugPayloadEncoder.GetCurrentTimestamp(), 0);
-        var rebirthMetric = SparkplugMetricBuilder.Create("Rebirth")
+        var rebirthMetric = SparkplugMetricBuilder.Create(SparkplugPayloadEncoder.NodeControlRebirthMetricName)
             .WithBooleanValue(true)
             .Build();
         payload.Metrics.Add(rebirthMetric);

--- a/Source/HiveMQtt.Sparkplug/Payload/SparkplugPayloadEncoder.cs
+++ b/Source/HiveMQtt.Sparkplug/Payload/SparkplugPayloadEncoder.cs
@@ -146,4 +146,10 @@ public static class SparkplugPayloadEncoder
     /// <returns>A metric with name "bdSeq" and the given value.</returns>
     public static Protobuf.Payload.Types.Metric CreateBdSeqMetric(ulong bdSeq) =>
         SparkplugMetricBuilder.Create(BdSeqMetricName).WithUInt64Value(bdSeq).Build();
+
+    /// <summary>
+    /// Metric name for the Sparkplug Node Control Rebirth command. Used in NCMD and NBIRTH.
+    /// Per Sparkplug B 3.0 specification section 12.13, the metric name MUST be "Node Control/Rebirth".
+    /// </summary>
+    public const string NodeControlRebirthMetricName = "Node Control/Rebirth";
 }

--- a/Source/HiveMQtt.Sparkplug/README.md
+++ b/Source/HiveMQtt.Sparkplug/README.md
@@ -108,12 +108,12 @@ See the [Examples](../../Examples) folder for runnable Host and Edge Node sample
 
 ### Rebirth handling
 
-When a Host sends a **Rebirth** command (NCMD with a `Rebirth` boolean metric set to true), the Edge Node should publish a fresh Node Birth so the Host receives an up-to-date NBIRTH. In your `NodeCommandReceived` handler, check for the Rebirth metric and call **`PublishNodeBirthAsync`**; if the node has devices, re-publish their DBIRTHs as well.
+When a Host sends a **Rebirth** command (NCMD with a `Node Control/Rebirth` boolean metric set to true), the Edge Node should publish a fresh Node Birth so the Host receives an up-to-date NBIRTH. In your `NodeCommandReceived` handler, check for the Rebirth metric and call **`PublishNodeBirthAsync`**; if the node has devices, re-publish their DBIRTHs as well.
 
 ```csharp
 edgeNode.NodeCommandReceived += async (_, e) =>
 {
-    var isRebirth = e.Payload.Metrics.Any(m => m.Name == "Rebirth" && m.BooleanValue);
+    var isRebirth = e.Payload.Metrics.Any(m => m.Name == SparkplugPayloadEncoder.NodeControlRebirthMetricName && m.BooleanValue);
     if (isRebirth)
     {
         await edgeNode.PublishNodeBirthAsync(null); // add node metrics if needed

--- a/Tests/HiveMQtt.Sparkplug.Test/EdgeNode/SparkplugEdgeNodeTest.cs
+++ b/Tests/HiveMQtt.Sparkplug.Test/EdgeNode/SparkplugEdgeNodeTest.cs
@@ -218,14 +218,14 @@ public class SparkplugEdgeNodeTest
 
         var topic = "spBv1.0/g1/NCMD/n1";
         var payload = SparkplugPayloadEncoder.CreatePayload(SparkplugPayloadEncoder.GetCurrentTimestamp(), 0);
-        payload.Metrics.Add(SparkplugMetricBuilder.Create("Rebirth").WithBooleanValue(true).Build());
+        payload.Metrics.Add(SparkplugMetricBuilder.Create(SparkplugPayloadEncoder.NodeControlRebirthMetricName).WithBooleanValue(true).Build());
         client.SimulateMessageReceived(topic, SparkplugPayloadEncoder.Encode(payload));
 
         await Task.Delay(100).ConfigureAwait(false);
 
         received.Should().NotBeNull();
         received!.Topic.MessageType.Should().Be(SparkplugMessageType.NCMD);
-        received.Payload.Metrics.Should().ContainSingle(m => m.Name == "Rebirth");
+        received.Payload.Metrics.Should().ContainSingle(m => m.Name == SparkplugPayloadEncoder.NodeControlRebirthMetricName);
     }
 
     [Test]
@@ -395,7 +395,7 @@ public class SparkplugEdgeNodeTest
 
         var topic = "spBv1.0/g1/NCMD/n1";
         var payload = SparkplugPayloadEncoder.CreatePayload(SparkplugPayloadEncoder.GetCurrentTimestamp(), 0);
-        payload.Metrics.Add(SparkplugMetricBuilder.Create("Rebirth").WithBooleanValue(true).Build());
+        payload.Metrics.Add(SparkplugMetricBuilder.Create(SparkplugPayloadEncoder.NodeControlRebirthMetricName).WithBooleanValue(true).Build());
         client.SimulateMessageReceived(topic, SparkplugPayloadEncoder.Encode(payload));
 
         await Task.Delay(100).ConfigureAwait(false);

--- a/Tests/HiveMQtt.Sparkplug.Test/HostApplication/SparkplugHostApplicationTest.cs
+++ b/Tests/HiveMQtt.Sparkplug.Test/HostApplication/SparkplugHostApplicationTest.cs
@@ -274,7 +274,7 @@ public class SparkplugHostApplicationTest
         client.PublishedMessages[0].Topic.Should().Be("spBv1.0/g1/NCMD/n1");
         client.PublishedMessages[0].Payload.Should().NotBeNull();
         var decoded = SparkplugPayloadEncoder.Decode(client.PublishedMessages[0].Payload!);
-        decoded.Metrics.Should().ContainSingle(m => m.Name == "Rebirth" && m.Datatype == (uint)DataType.Boolean && m.BooleanValue);
+        decoded.Metrics.Should().ContainSingle(m => m.Name == SparkplugPayloadEncoder.NodeControlRebirthMetricName && m.Datatype == (uint)DataType.Boolean && m.BooleanValue);
     }
 
     [Test]


### PR DESCRIPTION
## Summary

This PR fixes the Rebirth metric name to comply with the [Sparkplug B 3.0 specification](https://sparkplug.eclipse.org/specification/version/3.0).

Per section 12.13:
> The NBIRTH message MUST include a metric with the name Node Control/Rebirth. It MUST be of datatype boolean and have a value of false.

## Changes

- Added `NodeControlRebirthMetricName` constant (`"Node Control/Rebirth"`) in `SparkplugPayloadEncoder`
- Updated `HostApplication.PublishRebirthCommandAsync()` to use the correct metric name when sending NCMD Rebirth commands
- Updated `EdgeNode.StartAsync()` to include the Rebirth metric in NBIRTH (value: `false`)
- Updated `EdgeNode.PublishNodeBirthAsync()` to include the Rebirth metric in NBIRTH (value: `false`)
- Updated all tests to verify the correct metric name
- Updated documentation with correct examples

## Breaking Change

This is a breaking change for existing users who were checking for the literal string `"Rebirth"` in their code. They should update their code to use `SparkplugPayloadEncoder.NodeControlRebirthMetricName`.

Fixes #330