### PR TITLE
Add Node Control metric constants for Reboot and Next Server

### DIFF
--- a/Source/HiveMQtt.Sparkplug/Payload/SparkplugPayloadEncoder.cs
+++ b/Source/HiveMQtt.Sparkplug/Payload/SparkplugPayloadEncoder.cs
@@ -152,4 +152,18 @@ public static class SparkplugPayloadEncoder
     /// Per Sparkplug B 3.0 specification section 12.13, the metric name MUST be "Node Control/Rebirth".
     /// </summary>
     public const string NodeControlRebirthMetricName = "Node Control/Rebirth";
+
+    /// <summary>
+    /// Metric name for the Sparkplug Node Control Reboot command. Used in NCMD.
+    /// Per Sparkplug B 3.0 specification, an Edge Node that supports reboot should include
+    /// this metric in NBIRTH with a boolean value of false.
+    /// </summary>
+    public const string NodeControlRebootMetricName = "Node Control/Reboot";
+
+    /// <summary>
+    /// Metric name for the Sparkplug Node Control Next Server command. Used in NCMD.
+    /// Per Sparkplug B 3.0 specification, an Edge Node that supports server switching should
+    /// include this metric in NBIRTH with a boolean value of false.
+    /// </summary>
+    public const string NodeControlNextServerMetricName = "Node Control/Next Server";
 }


### PR DESCRIPTION
## Summary

Adds constants for the optional Node Control metrics defined in the Sparkplug B 3.0 specification:

- `NodeControlRebootMetricName = "Node Control/Reboot"`
- `NodeControlNextServerMetricName = "Node Control/Next Server"`

## Background

The Sparkplug B 3.0 specification defines these optional Node Control metrics in section 12.13. Edge Nodes that support reboot functionality or multiple server switching should include these metrics in their NBIRTH with boolean values of `false` by default.

## Usage

Users can now reference these constants instead of hardcoding the metric names:

```csharp
// For Edge Nodes that support reboot
birthPayload.Metrics.Add(
    SparkplugMetricBuilder.Create(SparkplugPayloadEncoder.NodeControlRebootMetricName)
        .WithBooleanValue(false)
        .Build());

// For Edge Nodes that support multiple servers
birthPayload.Metrics.Add(
    SparkplugMetricBuilder.Create(SparkplugPayloadEncoder.NodeControlNextServerMetricName)
        .WithBooleanValue(false)
        .Build());
```

## Note

These metrics are **optional** per the specification. Edge Nodes only need to include them if they implement the corresponding functionality.