### PR TITLE
Add configurable deduplication behavior for overlapping subscriptions

### DIFF
--- a/Documentation/docs/hivemqtt/hivemqclient.md
+++ b/Documentation/docs/hivemqtt/hivemqclient.md
@@ -348,6 +348,65 @@ client.OnMessageReceived += MessageHandler;
 await client.ConnectAsync();
 ```
 
+## Overlapping Subscriptions
+
+When you subscribe to overlapping topic patterns (e.g., `sensors/#` and `sensors/+/temperature`), a single published message may match multiple subscriptions. The `OverlappingSubscriptionBehavior` option controls how the client handles this.
+
+### Configuration
+
+```csharp
+var options = new HiveMQClientOptionsBuilder()
+    .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
+    .Build();
+
+var client = new HiveMQClient(options);
+```
+
+### Behavior Options
+
+| Option | Description |
+|--------|-------------|
+| `FireAllMatchingHandlers` (default) | Fire a handler for **each** matching subscription. Use this for backward compatibility. |
+| `FireFirstMatchingHandler` | Fire only the **first** matching subscription handler. Recommended for new applications. |
+
+:::tip Recommendation
+
+For new applications, use `FireFirstMatchingHandler` to ensure each message is processed exactly once, regardless of how many subscriptions match.
+
+:::
+
+### Example: FireFirstMatchingHandler
+
+```csharp
+var options = new HiveMQClientOptionsBuilder()
+    .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
+    .Build();
+
+var client = new HiveMQClient(options);
+
+// Subscribe to overlapping patterns
+var opts1 = new SubscribeOptions();
+opts1.TopicFilters.Add(new TopicFilter("sensors/#", QualityOfService.AtLeastOnceDelivery));
+opts1.Handlers["sensors/#"] = (s, e) => Console.WriteLine("Wildcard handler");
+await client.SubscribeAsync(opts1);  // First subscription
+
+var opts2 = new SubscribeOptions();
+opts2.TopicFilters.Add(new TopicFilter("sensors/+/temperature", QualityOfService.AtLeastOnceDelivery));
+opts2.Handlers["sensors/+/temperature"] = (s, e) => Console.WriteLine("Specific handler");
+await client.SubscribeAsync(opts2);  // Second subscription
+
+// Global handler always fires regardless of setting
+client.OnMessageReceived += (s, e) => Console.WriteLine("Global handler");
+
+// Publish to sensors/livingroom/temperature
+// Output:
+// Global handler
+// Wildcard handler
+// (Specific handler does NOT fire - only first match fires)
+```
+
+For more details, see [Overlapping Subscriptions](/docs/hivemqtt/subscribing#overlapping-subscriptions).
+
 ## Unsubscribing
 
 The `HiveMQClient` provides multiple ways to unsubscribe:

--- a/Documentation/docs/hivemqtt/reference/client_options_builder.md
+++ b/Documentation/docs/hivemqtt/reference/client_options_builder.md
@@ -158,6 +158,30 @@ Enables or disables manual acknowledgement of incoming QoS 1 and QoS 2 publishes
 
 **Added in:** v0.40.0
 
+### `WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior behavior)`
+
+Sets the behavior for handling messages that match multiple overlapping subscriptions.
+
+**Added in:** v0.42.0
+
+**Description:** When a client subscribes to overlapping topic patterns (e.g., `sensors/#` and `sensors/+/temperature`), a message published to a matching topic will match both subscriptions. This setting controls whether the message handler fires once or for each matching subscription.
+
+| Value | Description |
+|-------|-------------|
+| `FireAllMatchingHandlers` (default) | Fire a handler for each matching subscription |
+| `FireFirstMatchingHandler` | Fire only the first matching subscription handler |
+
+**Example:**
+```csharp
+// Recommended for new applications - each message fires once
+WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
+
+// Default for backward compatibility - each matching subscription fires
+WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireAllMatchingHandlers)
+```
+
+**See Also:** [Overlapping Subscriptions](/docs/hivemqtt/subscribing#overlapping-subscriptions) for detailed behavior documentation.
+
 ### `WithSessionExpiryInterval(int sessionExpiryInterval)`
 
 Sets the session expiry interval.

--- a/Documentation/docs/hivemqtt/subscribing.md
+++ b/Documentation/docs/hivemqtt/subscribing.md
@@ -233,6 +233,180 @@ var options = builder.WithSubscription(
     .Build();
 ```
 
+## Overlapping Subscriptions
+
+### The Problem
+
+When you subscribe to overlapping topic patterns, a single published message may match multiple subscriptions. For example:
+
+```csharp
+await client.SubscribeAsync("sensors/#");           // Matches: sensors/temperature/livingroom
+await client.SubscribeAsync("sensors/+/temperature"); // Matches: sensors/livingroom/temperature
+```
+
+A message published to `sensors/livingroom/temperature` matches **both** subscriptions.
+
+Depending on your MQTT broker, this can result in:
+- **Single delivery**: One PUBLISH packet sent by the broker
+- **Multiple deliveries**: Multiple PUBLISH packets (one per matching subscription)
+
+The `OverlappingSubscriptionBehavior` setting controls how the client handles this.
+
+### Behavior Options
+
+The `HiveMQClientOptions.OverlappingSubscriptionBehavior` property controls this behavior:
+
+| Option | Description | When to Use |
+|--------|-------------|-------------|
+| `FireAllMatchingHandlers` (default) | Fires a handler for **each** matching subscription | Backward compatibility, different logic per subscription |
+| `FireFirstMatchingHandler` | Fires only the **first** matching subscription handler | Single message processing, simpler handling |
+
+### Option 1: `FireAllMatchingHandlers` (Default)
+
+**Behavior**: The `OnMessageReceived` event fires **once for each matching subscription** that has a handler registered.
+
+**Example**:
+
+```csharp
+var options = new HiveMQClientOptionsBuilder()
+    .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireAllMatchingHandlers) // Default
+    .Build();
+
+var client = new HiveMQClient(options);
+
+var opts1 = new SubscribeOptions();
+opts1.TopicFilters.Add(new TopicFilter("sensors/#", QualityOfService.AtLeastOnceDelivery));
+opts1.Handlers["sensors/#"] = (s, e) => Console.WriteLine("Handler 1: Wildcard match");
+await client.SubscribeAsync(opts1);
+
+var opts2 = new SubscribeOptions();
+opts2.TopicFilters.Add(new TopicFilter("sensors/+/temperature", QualityOfService.AtLeastOnceDelivery));
+opts2.Handlers["sensors/+/temperature"] = (s, e) => Console.WriteLine("Handler 2: Specific match");
+await client.SubscribeAsync(opts2);
+
+// Publish to sensors/livingroom/temperature
+// Output:
+// Handler 1: Wildcard match
+// Handler 2: Specific match
+```
+
+:::note
+
+Only subscriptions **with handlers** fire events. The global `OnMessageReceived` event always fires separately.
+
+:::
+
+### Option 2: `FireFirstMatchingHandler` (Recommended)
+
+**Behavior**: The `OnMessageReceived` event fires **only once** for the first matching subscription.
+
+**Example**:
+
+```csharp
+var options = new HiveMQClientOptionsBuilder()
+    .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
+    .Build();
+
+var client = new HiveMQClient(options);
+
+var opts1 = new SubscribeOptions();
+opts1.TopicFilters.Add(new TopicFilter("sensors/#", QualityOfService.AtLeastOnceDelivery));
+opts1.Handlers["sensors/#"] = (s, e) => Console.WriteLine("Handler 1: Wildcard match");
+await client.SubscribeAsync(opts1);  // First subscription
+
+var opts2 = new SubscribeOptions();
+opts2.TopicFilters.Add(new TopicFilter("sensors/+/temperature", QualityOfService.AtLeastOnceDelivery));
+opts2.Handlers["sensors/+/temperature"] = (s, e) => Console.WriteLine("Handler 2: Specific match");
+await client.SubscribeAsync(opts2);  // Second subscription
+
+// Publish to sensors/livingroom/temperature
+// Output:
+// Handler 1: Wildcard match
+// (Handler 2 does NOT fire because it's not the first match)
+```
+
+:::tip
+
+"First" means **first in subscription order** (the order you called `SubscribeAsync`). The global `OnMessageReceived` event always fires regardless of this setting.
+
+:::
+
+### Edge Cases
+
+#### First Subscription Has No Handler
+
+If the first matching subscription has no handler, but a later one does:
+
+```csharp
+await client.SubscribeAsync("sensors/#");  // No per-subscription handler
+
+var opts = new SubscribeOptions();
+opts.TopicFilters.Add(new TopicFilter("sensors/+/temperature", QualityOfService.AtLeastOnceDelivery));
+opts.Handlers["sensors/+/temperature"] = MyHandler;
+await client.SubscribeAsync(opts);
+
+// Publish to sensors/livingroom/temperature
+// With FireFirstMatchingHandler:
+//   - NO per-subscription handler fires (sensors/# was first but has no handler)
+//   - Global OnMessageReceived still fires
+```
+
+**Recommendation**: Either register handlers on all overlapping subscriptions, use the global `OnMessageReceived` event, or ensure your most specific subscription is added first.
+
+#### Mixed Global and Per-Subscription Handlers
+
+The global `OnMessageReceived` event is **not affected** by the behavior setting:
+
+```csharp
+var options = new HiveMQClientOptionsBuilder()
+    .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
+    .Build();
+
+var client = new HiveMQClient(options);
+
+// Global handler
+client.OnMessageReceived += (s, e) => Console.WriteLine("Global handler");
+
+// Per-subscription handler
+var opts = new SubscribeOptions();
+opts.TopicFilters.Add(new TopicFilter("sensors/#", QualityOfService.AtLeastOnceDelivery));
+opts.Handlers["sensors/#"] = (s, e) => Console.WriteLine("Per-subscription handler");
+await client.SubscribeAsync(opts);
+
+// Publish to sensors/temperature
+// Output:
+// Global handler
+// Per-subscription handler
+// (Both fire - global is always independent)
+```
+
+### Quick Reference Table
+
+| Scenario | `FireAllMatchingHandlers` | `FireFirstMatchingHandler` |
+|----------|---------------------------|---------------------------|
+| 3 overlapping subs, all with handlers | 3 handler calls | 1 handler call (first only) |
+| 3 overlapping subs, only 2nd has handler | 1 handler call (2nd only) | 0 handler calls (1st has none) |
+| Global + 2 per-sub handlers | Global + 2 handlers | Global + 1 handler (first only) |
+| Global only (no per-sub handlers) | Global fires once | Global fires once |
+
+### Migration Guide
+
+#### For New Users
+
+We recommend using `FireFirstMatchingHandler` for new applications:
+
+```csharp
+var options = new HiveMQClientOptionsBuilder()
+    .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
+    .Build();
+
+var client = new HiveMQClient(options);
+```
+
+#### For Existing Users
+
+**No changes required** - the default remains `FireAllMatchingHandlers` for backward compatibility.
+
 ## See Also
 
 * [MQTT Topics, Wildcards, & Best Practices](https://www.hivemq.com/blog/mqtt-essentials-part-5-mqtt-topics-best-practices/)

--- a/Source/HiveMQtt/Client/HiveMQClientEvents.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientEvents.cs
@@ -319,20 +319,24 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
             sub.MessageReceivedHandler is not null &&
             MatchTopic(sub.TopicFilter.Topic, packet.Message.Topic));
 
-        // Create eventArgs only if we have subscription handlers (optimization: avoid allocation if not needed)
-        if (matchingSubscriptions.Any())
+        // Check behavior setting for overlapping subscriptions
+        var behavior = this.Options.OverlappingSubscriptionBehavior;
+
+        if (behavior == OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
         {
-            var eventArgs = new OnMessageReceivedEventArgs(
-                packet.Message,
-                packet.Message.QoS == QualityOfService.AtMostOnceDelivery ? null : packet.PacketIdentifier);
-            foreach (var subscription in matchingSubscriptions)
+            // Fire only the first matching subscription handler
+            var firstMatch = matchingSubscriptions.FirstOrDefault();
+            if (firstMatch != null)
             {
-                // We have a per-subscription message handler.
+                var eventArgs = new OnMessageReceivedEventArgs(
+                    packet.Message,
+                    packet.Message.QoS == QualityOfService.AtMostOnceDelivery ? null : packet.PacketIdentifier);
+
                 _ = Task.Run(() =>
                 {
                     try
                     {
-                        subscription.MessageReceivedHandler?.Invoke(this, eventArgs);
+                        firstMatch.MessageReceivedHandler?.Invoke(this, eventArgs);
                     }
                     catch (Exception e)
                     {
@@ -342,6 +346,35 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
                 });
 
                 messageHandled = true;
+            }
+        }
+        else
+        {
+            // Default: FireAllMatchingHandlers - fire all matching subscription handlers
+            // Create eventArgs only if we have subscription handlers (optimization: avoid allocation if not needed)
+            if (matchingSubscriptions.Any())
+            {
+                var eventArgs = new OnMessageReceivedEventArgs(
+                    packet.Message,
+                    packet.Message.QoS == QualityOfService.AtMostOnceDelivery ? null : packet.PacketIdentifier);
+                foreach (var subscription in matchingSubscriptions)
+                {
+                    // We have a per-subscription message handler.
+                    _ = Task.Run(() =>
+                    {
+                        try
+                        {
+                            subscription.MessageReceivedHandler?.Invoke(this, eventArgs);
+                        }
+                        catch (Exception e)
+                        {
+                            Logger.Error(
+                                $"per-subscription MessageReceivedEventLauncher faulted ({packet.Message.Topic}): {e.Message}");
+                        }
+                    });
+
+                    messageHandled = true;
+                }
             }
         }
 

--- a/Source/HiveMQtt/Client/HiveMQClientOptionsBuilder.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientOptionsBuilder.cs
@@ -21,6 +21,7 @@ using System.Net;
 using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using HiveMQtt.Client.Options;
+using HiveMQtt.MQTT5.Types;
 
 /// <summary>
 /// A builder for HiveMQClientOptions.
@@ -856,6 +857,30 @@ public class HiveMQClientOptionsBuilder
     public HiveMQClientOptionsBuilder WithAutomaticReconnect(bool automaticReconnect)
     {
         this.options.AutomaticReconnect = automaticReconnect;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the behavior for handling messages that match multiple overlapping subscriptions.
+    /// <para>
+    /// When a client subscribes to overlapping topic patterns (e.g., "/room/a/b/c/#" and "/room/a/b/#"),
+    /// a message published to "/room/a/b/c/whatever" will match both subscriptions. This setting controls
+    /// whether the OnMessageReceived event fires once or for each matching subscription.
+    /// </para>
+    /// <para>
+    /// Use <see cref="OverlappingSubscriptionBehavior.FireFirstMatchingHandler"/> to ensure each message
+    /// is delivered only once to your application, regardless of how many subscriptions match.
+    /// </para>
+    /// <para>
+    /// Use <see cref="OverlappingSubscriptionBehavior.FireAllMatchingHandlers"/> (default) to maintain
+    /// backward compatibility where each matching subscription's handler fires separately.
+    /// </para>
+    /// </summary>
+    /// <param name="behavior">The desired behavior for overlapping subscriptions.</param>
+    /// <returns>The HiveMQClientOptionsBuilder instance.</returns>
+    public HiveMQClientOptionsBuilder WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior behavior)
+    {
+        this.options.OverlappingSubscriptionBehavior = behavior;
         return this;
     }
 

--- a/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
+++ b/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
@@ -23,6 +23,7 @@ using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using HiveMQtt.Client;
 using HiveMQtt.Client.Exceptions;
+using HiveMQtt.MQTT5.Types;
 
 /// <summary>
 /// A class to manage the MQTT options available in the Client.
@@ -225,6 +226,19 @@ public class HiveMQClientOptions
     /// Reconnection attempts will be made with a retry back off strategy.
     /// </summary>
     public bool AutomaticReconnect { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating how to handle messages that match multiple overlapping subscriptions.
+    /// <para>
+    /// When a client has multiple subscriptions that match the same topic (e.g., "/room/a/b/c/#" and "/room/a/b/#"),
+    /// this setting controls whether the OnMessageReceived event fires once or multiple times.
+    /// </para>
+    /// <para>
+    /// Default is <see cref="OverlappingSubscriptionBehavior.FireAllMatchingHandlers"/> for backward compatibility.
+    /// Set to <see cref="OverlappingSubscriptionBehavior.FireFirstMatchingHandler"/> to receive each message only once.
+    /// </para>
+    /// </summary>
+    public OverlappingSubscriptionBehavior OverlappingSubscriptionBehavior { get; set; } = OverlappingSubscriptionBehavior.FireAllMatchingHandlers;
 
     /// <summary>
     /// Gets or sets the WebSocket keep-alive interval.

--- a/Source/HiveMQtt/MQTT5/Types/SubscriptionBehavior.cs
+++ b/Source/HiveMQtt/MQTT5/Types/SubscriptionBehavior.cs
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026-present HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace HiveMQtt.MQTT5.Types;
+
+/// <summary>
+/// Defines how the client handles messages that match multiple overlapping subscriptions.
+/// </summary>
+/// <remarks>
+/// When a client subscribes to overlapping topic patterns (e.g., "sensors/#" and "sensors/+/temperature"),
+/// a single message published to a matching topic (e.g., "sensors/livingroom/temperature") will match
+/// both subscriptions. This enum controls whether the message handler fires once or for each matching subscription.
+/// </remarks>
+public enum OverlappingSubscriptionBehavior
+{
+    /// <summary>
+    /// Fire the message handler for every matching subscription that has a handler registered.
+    /// This is the default behavior for backward compatibility.
+    /// </summary>
+    /// <remarks>
+    /// If you have 3 overlapping subscriptions and all have handlers, the handler will fire 3 times
+    /// for a message that matches all 3 subscriptions.
+    /// </remarks>
+    FireAllMatchingHandlers,
+
+    /// <summary>
+    /// Fire only the first matching subscription handler based on subscription order.
+    /// This is the recommended behavior for most applications.
+    /// </summary>
+    /// <remarks>
+    /// If you have 3 overlapping subscriptions and all have handlers, only the first subscription's
+    /// handler (in the order they were added) will fire for a message that matches all 3 subscriptions.
+    /// The global OnMessageReceived event is not affected by this setting and always fires.
+    /// </remarks>
+    FireFirstMatchingHandler
+}

--- a/Tests/HiveMQtt.Test/HiveMQClient/OverlappingSubscriptionTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/OverlappingSubscriptionTest.cs
@@ -1,0 +1,286 @@
+namespace HiveMQtt.Test.HiveMQClient;
+
+using System.Threading.Tasks;
+using HiveMQtt.Client;
+using HiveMQtt.Client.Events;
+using HiveMQtt.Client.Options;
+using HiveMQtt.MQTT5.ReasonCodes;
+using HiveMQtt.MQTT5.Types;
+using Xunit;
+
+/// <summary>
+/// Tests for overlapping subscription behavior (GitHub Issue #329).
+/// </summary>
+[Collection("Broker")]
+public class OverlappingSubscriptionTest
+{
+    /// <summary>
+    /// Test that FireAllMatchingHandlers (default) fires all matching subscription handlers.
+    /// </summary>
+    [Fact]
+    public async Task FireAllMatchingHandlers_Behavior_FiresAllHandlers()
+    {
+        var options = new HiveMQClientOptionsBuilder()
+            .WithClientId("FireAllMatchingHandlers_FiresAll")
+            .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireAllMatchingHandlers)
+            .Build();
+
+        var client = new HiveMQClient(options);
+
+        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+        Assert.Equal(ConnAckReasonCode.Success, connectResult.ReasonCode);
+
+        var prefix = $"tests/overlapping/all/{Guid.NewGuid()}";
+
+        var handler1Count = 0;
+        var handler2Count = 0;
+        var handler3Count = 0;
+        var messageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Subscribe to overlapping topics with individual handlers
+        var opts1 = new SubscribeOptions();
+        opts1.TopicFilters.Add(new TopicFilter($"{prefix}/room/a/b/c/#", QualityOfService.AtLeastOnceDelivery));
+        opts1.Handlers[$"{prefix}/room/a/b/c/#"] = (s, e) =>
+        {
+            Interlocked.Increment(ref handler1Count);
+            messageReceived.TrySetResult(true);
+        };
+        await client.SubscribeAsync(opts1).ConfigureAwait(false);
+
+        var opts2 = new SubscribeOptions();
+        opts2.TopicFilters.Add(new TopicFilter($"{prefix}/room/a/b/#", QualityOfService.AtLeastOnceDelivery));
+        opts2.Handlers[$"{prefix}/room/a/b/#"] = (s, e) =>
+        {
+            Interlocked.Increment(ref handler2Count);
+        };
+        await client.SubscribeAsync(opts2).ConfigureAwait(false);
+
+        var opts3 = new SubscribeOptions();
+        opts3.TopicFilters.Add(new TopicFilter($"{prefix}/room/a/#", QualityOfService.AtLeastOnceDelivery));
+        opts3.Handlers[$"{prefix}/room/a/#"] = (s, e) =>
+        {
+            Interlocked.Increment(ref handler3Count);
+        };
+        await client.SubscribeAsync(opts3).ConfigureAwait(false);
+
+        // Publish a message that matches all three subscriptions
+        await client.PublishAsync($"{prefix}/room/a/b/c/whatever", "test", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        // Wait for message to be received with timeout
+        await messageReceived.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await Task.Delay(500).ConfigureAwait(false); // Give time for all handlers to fire
+
+        // With FireAllMatchingHandlers, all 3 handlers should fire
+        Assert.True(handler1Count >= 1, $"Handler 1 should have fired at least once, but fired {handler1Count} times");
+        Assert.True(handler2Count >= 1, $"Handler 2 should have fired at least once, but fired {handler2Count} times");
+        Assert.True(handler3Count >= 1, $"Handler 3 should have fired at least once, but fired {handler3Count} times");
+
+        await client.DisconnectAsync().ConfigureAwait(false);
+        client.Dispose();
+    }
+
+    /// <summary>
+    /// Test that FireFirstMatchingHandler fires only the first matching subscription handler.
+    /// </summary>
+    [Fact]
+    public async Task FireFirstMatchingHandler_Behavior_FiresOnlyFirstHandler()
+    {
+        var options = new HiveMQClientOptionsBuilder()
+            .WithClientId("FireFirstMatchingHandler_FiresFirst")
+            .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
+            .Build();
+
+        var client = new HiveMQClient(options);
+
+        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+        Assert.Equal(ConnAckReasonCode.Success, connectResult.ReasonCode);
+
+        var prefix = $"tests/overlapping/first/{Guid.NewGuid()}";
+
+        var handler1Count = 0;
+        var handler2Count = 0;
+        var handler3Count = 0;
+        var messageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Subscribe to overlapping topics with individual handlers (order matters!)
+        var opts1 = new SubscribeOptions();
+        opts1.TopicFilters.Add(new TopicFilter($"{prefix}/room/a/b/c/#", QualityOfService.AtLeastOnceDelivery));
+        opts1.Handlers[$"{prefix}/room/a/b/c/#"] = (s, e) =>
+        {
+            Interlocked.Increment(ref handler1Count);
+            messageReceived.TrySetResult(true);
+        };
+        await client.SubscribeAsync(opts1).ConfigureAwait(false);
+
+        var opts2 = new SubscribeOptions();
+        opts2.TopicFilters.Add(new TopicFilter($"{prefix}/room/a/b/#", QualityOfService.AtLeastOnceDelivery));
+        opts2.Handlers[$"{prefix}/room/a/b/#"] = (s, e) =>
+        {
+            Interlocked.Increment(ref handler2Count);
+        };
+        await client.SubscribeAsync(opts2).ConfigureAwait(false);
+
+        var opts3 = new SubscribeOptions();
+        opts3.TopicFilters.Add(new TopicFilter($"{prefix}/room/a/#", QualityOfService.AtLeastOnceDelivery));
+        opts3.Handlers[$"{prefix}/room/a/#"] = (s, e) =>
+        {
+            Interlocked.Increment(ref handler3Count);
+        };
+        await client.SubscribeAsync(opts3).ConfigureAwait(false);
+
+        // Publish a message that matches all three subscriptions
+        await client.PublishAsync($"{prefix}/room/a/b/c/whatever", "test", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        // Wait for message to be received with timeout
+        await messageReceived.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await Task.Delay(500).ConfigureAwait(false); // Give time to ensure other handlers don't fire
+
+        // With FireFirstMatchingHandler, only the first handler should fire
+        Assert.True(handler1Count >= 1, $"Handler 1 (first) should have fired at least once, but fired {handler1Count} times");
+        Assert.Equal(0, handler2Count);
+        Assert.Equal(0, handler3Count);
+
+        await client.DisconnectAsync().ConfigureAwait(false);
+        client.Dispose();
+    }
+
+    /// <summary>
+    /// Test that FireFirstMatchingHandler with global handler fires both global and first subscription handler.
+    /// </summary>
+    [Fact]
+    public async Task FireFirstMatchingHandler_WithGlobalHandler_BothFire()
+    {
+        var options = new HiveMQClientOptionsBuilder()
+            .WithClientId("FireFirst_GlobalAndPerSub")
+            .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
+            .Build();
+
+        var client = new HiveMQClient(options);
+
+        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+        Assert.Equal(ConnAckReasonCode.Success, connectResult.ReasonCode);
+
+        var prefix = $"tests/overlapping/global/{Guid.NewGuid()}";
+
+        var globalCount = 0;
+        var perSubCount = 0;
+        var messageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Set up global handler
+        client.OnMessageReceived += (s, e) =>
+        {
+            if (e.PublishMessage.Topic!.StartsWith(prefix))
+            {
+                Interlocked.Increment(ref globalCount);
+            }
+        };
+
+        // Set up per-subscription handler
+        var opts = new SubscribeOptions();
+        opts.TopicFilters.Add(new TopicFilter($"{prefix}/#", QualityOfService.AtLeastOnceDelivery));
+        opts.Handlers[$"{prefix}/#"] = (s, e) =>
+        {
+            Interlocked.Increment(ref perSubCount);
+            messageReceived.TrySetResult(true);
+        };
+        await client.SubscribeAsync(opts).ConfigureAwait(false);
+
+        // Publish a message
+        await client.PublishAsync($"{prefix}/test", "test", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        // Wait for message to be received with timeout
+        await messageReceived.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await Task.Delay(500).ConfigureAwait(false);
+
+        // Both global and per-subscription handler should fire
+        Assert.True(globalCount >= 1, $"Global handler should have fired at least once, but fired {globalCount} times");
+        Assert.True(perSubCount >= 1, $"Per-subscription handler should have fired at least once, but fired {perSubCount} times");
+
+        await client.DisconnectAsync().ConfigureAwait(false);
+        client.Dispose();
+    }
+
+    /// <summary>
+    /// Test that the default behavior is FireAllMatchingHandlers.
+    /// </summary>
+    [Fact]
+    public void DefaultBehavior_IsFireAllMatchingHandlers()
+    {
+        var options = new HiveMQClientOptions();
+
+        Assert.Equal(OverlappingSubscriptionBehavior.FireAllMatchingHandlers, options.OverlappingSubscriptionBehavior);
+    }
+
+    /// <summary>
+    /// Test that the builder correctly sets the behavior.
+    /// </summary>
+    [Fact]
+    public void Builder_SetsOverlappingSubscriptionBehavior()
+    {
+        var options = new HiveMQClientOptionsBuilder()
+            .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
+            .Build();
+
+        Assert.Equal(OverlappingSubscriptionBehavior.FireFirstMatchingHandler, options.OverlappingSubscriptionBehavior);
+    }
+
+    /// <summary>
+    /// Test edge case: FireFirstMatchingHandler when first subscription has no handler.
+    /// </summary>
+    [Fact]
+    public async Task FireFirstMatchingHandler_FirstSubscriptionNoHandler_DoesNotFire()
+    {
+        var options = new HiveMQClientOptionsBuilder()
+            .WithClientId("FireFirst_FirstNoHandler")
+            .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
+            .Build();
+
+        var client = new HiveMQClient(options);
+
+        var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+        Assert.Equal(ConnAckReasonCode.Success, connectResult.ReasonCode);
+
+        var prefix = $"tests/overlapping/nohandler/{Guid.NewGuid()}";
+
+        var globalCount = 0;
+        var perSubCount = 0;
+        var messageReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // Set up global handler
+        client.OnMessageReceived += (s, e) =>
+        {
+            if (e.PublishMessage.Topic!.StartsWith(prefix))
+            {
+                Interlocked.Increment(ref globalCount);
+                messageReceived.TrySetResult(true);
+            }
+        };
+
+        // First subscription WITHOUT a per-subscription handler
+        await client.SubscribeAsync($"{prefix}/#", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        // Second subscription WITH a per-subscription handler
+        var opts = new SubscribeOptions();
+        opts.TopicFilters.Add(new TopicFilter($"{prefix}/room/+", QualityOfService.AtLeastOnceDelivery));
+        opts.Handlers[$"{prefix}/room/+"] = (s, e) =>
+        {
+            Interlocked.Increment(ref perSubCount);
+        };
+        await client.SubscribeAsync(opts).ConfigureAwait(false);
+
+        // Publish a message that matches both
+        await client.PublishAsync($"{prefix}/room/1", "test", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        // Wait for message to be received with timeout
+        await messageReceived.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        await Task.Delay(500).ConfigureAwait(false);
+
+        // Global handler should fire, but per-subscription handler should NOT fire
+        // because the first matching subscription has no handler
+        Assert.True(globalCount >= 1, $"Global handler should have fired, but fired {globalCount} times");
+        Assert.Equal(0, perSubCount);
+
+        await client.DisconnectAsync().ConfigureAwait(false);
+        client.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements a configurable `OverlappingSubscriptionBehavior` option to address GitHub issue #329 where overlapping subscriptions caused duplicate message delivery.

## Problem

When a client subscribes to overlapping topic patterns (e.g., `sensors/#` and `sensors/+/temperature`), a single published message matching both subscriptions would fire the message handler multiple times - once for each matching subscription.

## Solution

Added a new `OverlappingSubscriptionBehavior` enum with two options:

- `FireAllMatchingHandlers` (default): Maintains backward compatibility by firing handlers for all matching subscriptions
- `FireFirstMatchingHandler`: Fires only the first matching subscription handler, preventing duplicate processing

## Usage

```csharp
var options = new HiveMQClientOptionsBuilder()
    .WithOverlappingSubscriptionBehavior(OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
    .Build();

var client = new HiveMQClient(options);
```

## Changes

- **New**: `SubscriptionBehavior.cs` - Enum defining the behavior options
- **Modified**: `HiveMQClientOptions.cs` - Added `OverlappingSubscriptionBehavior` property
- **Modified**: `HiveMQClientOptionsBuilder.cs` - Added `WithOverlappingSubscriptionBehavior()` method
- **Modified**: `HiveMQClientEvents.cs` - Updated `OnMessageReceivedEventLauncher()` to respect the setting
- **New**: `OverlappingSubscriptionTest.cs` - Comprehensive unit tests
- **Updated**: Documentation in `subscribing.md`, `client_options_builder.md`, and `hivemqclient.md`

## Backward Compatibility

The default behavior remains `FireAllMatchingHandlers`, ensuring existing code continues to work without modification.

Fixes #329