### PR TITLE
Serialize QoS 1/2 OnMessageReceived handlers in FIFO order

### DIFF
--- a/Documentation/docs/hivemqtt/events/Reference.md
+++ b/Documentation/docs/hivemqtt/events/Reference.md
@@ -18,7 +18,7 @@ General events are triggered by high-level operations such as connecting, subscr
 | AfterSubscribe  | `AfterSubscribeEventArgs` |  `SubscribeResult` |
 | BeforeUnsubscribe | `BeforeUnsubscribeEventArgs` | `UnsubscribeOptions`  |
 | AfterUnsubscribe  | `AfterUnsubscribeEventArgs` |  `UnsubscribeResult` |
-| OnMessageReceived | `OnMessageReceivedEventArgs` |  `MQTT5PublishMessage` |
+| OnMessageReceived | `OnMessageReceivedEventArgs` |  `MQTT5PublishMessage` — QoS 1/2 handlers are started in FIFO order; see [Message Ordering](/docs/hivemqtt/how-to/message-ordering) |
 | BeforeDisconnect | `BeforeDisconnectEventArgs` |  None |
 | AfterDisconnect | `AfterDisconnectEventArgs` |  `CleanDisconnect` |
 

--- a/Documentation/docs/hivemqtt/how-to/manual-ack.md
+++ b/Documentation/docs/hivemqtt/how-to/manual-ack.md
@@ -91,6 +91,18 @@ var options = new HiveMQClientOptionsBuilder()
     .Build();
 ```
 
+## Manual ack, ordering, and Receive Maximum
+
+QoS 1 and QoS 2 `OnMessageReceived` handlers are started in FIFO order on a per-client dispatch queue. See [Message Ordering](/docs/hivemqtt/how-to/message-ordering) for the full guarantee (including async handler limits).
+
+With manual ack enabled:
+
+- Each unacknowledged message holds a Receive Maximum slot until you call `AckAsync`.
+- Ordered dispatch means a slow handler delays the **start** of later handlers; slots remain held until each handler acknowledges.
+- If handlers are slow and the dispatch queue backs up, the broker may stop sending new QoS 1/2 messages sooner — that is expected back-pressure, not a protocol error.
+
+Keep handlers thin (parse and enqueue), perform heavy work on application-owned consumers, and call `AckAsync` when your processing is complete (or when you are ready for the broker to advance the window).
+
 ## Exceptions
 
 - **Manual ack not enabled:** Calling `AckAsync` when `ManualAckEnabled` is `false` throws `HiveMQttClientException`.
@@ -101,7 +113,9 @@ var options = new HiveMQClientOptionsBuilder()
 
 ## Thread safety
 
-`AckAsync` may be called from any thread, including directly from your `OnMessageReceived` handler (which may run on a thread-pool thread). You do not need to marshal the call back to a specific thread.
+QoS 1 and QoS 2 `OnMessageReceived` handlers run on a **dedicated message dispatch thread**. QoS 0 handlers may run on thread-pool threads.
+
+`AckAsync` may be called directly from your `OnMessageReceived` handler, including from the dispatch thread. You do not need to marshal the call back to a specific thread.
 
 ## Full example (HiveMQClient)
 

--- a/Documentation/docs/hivemqtt/how-to/message-ordering.md
+++ b/Documentation/docs/hivemqtt/how-to/message-ordering.md
@@ -1,0 +1,58 @@
+---
+sidebar_position: 10
+---
+
+# Message Ordering for OnMessageReceived
+
+MQTT 5.0 [section 4.6 (Message Ordering)](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901252) requires that QoS 1 and QoS 2 application messages be delivered to a client in the order they were sent for a given Topic Filter.
+
+HiveMQtt preserves that guarantee at the `OnMessageReceived` event boundary for **QoS 1 and QoS 2** messages.
+
+## What is guaranteed
+
+For QoS 1 and QoS 2 publishes:
+
+- Handlers are **started** in FIFO order on a single per-client dispatch queue.
+- Within one message, **global** `OnMessageReceived` handlers run first (in registration order), then **per-subscription** handlers (in subscription order, respecting `OverlappingSubscriptionBehavior`).
+- Handlers run on a **dedicated message dispatch thread** (not arbitrary thread-pool workers).
+
+The guarantee is **invocation (start) order**, not completion order.
+
+## Async handlers
+
+`OnMessageReceived` uses the standard .NET `EventHandler<T>` signature, which returns `void`. If you register an `async` lambda, it becomes **async void**:
+
+```csharp
+client.OnMessageReceived += async (sender, args) =>
+{
+    await SaveToDatabaseAsync(args);  // ordering does NOT extend past the first await
+};
+```
+
+Only synchronous work **before the first `await`** and handler **start order** are ordered. Work that continues after `await` may overlap with later messages.
+
+**Recommendation:** keep handlers thin and synchronous — parse the payload, enqueue to your own worker/channel, and return. Perform I/O and heavy logic on application-owned consumers.
+
+## QoS 0
+
+QoS 0 has no ordering requirement in the MQTT specification. HiveMQtt may invoke QoS 0 `OnMessageReceived` handlers concurrently via the thread pool.
+
+## Disconnect behavior
+
+When the client disconnects, the library **quiesces** the dispatch queue (similar to [Eclipse Paho](https://eclipse.dev/paho/files/javadoc/org/eclipse/paho/client/mqttv3/MqttClient.html#disconnect--)):
+
+- The **in-flight** handler (if any) is allowed to finish.
+- **Pending** handlers that have not started are **dropped**.
+- New messages are not dispatched after quiesce begins.
+
+After a successful reconnect, dispatch resumes for new messages.
+
+## Manual acknowledgement
+
+If you use [manual ack](/docs/hivemqtt/how-to/manual-ack), unacknowledged messages consume [Receive Maximum](https://www.hivemq.com/blog/mqtt5-essentials-part12-flow-control/) slots until you call `AckAsync`. Ordered dispatch with slow handlers can cause the broker to stop sending new messages sooner — that is expected back-pressure. See the manual ack guide for details.
+
+## See also
+
+* [Subscribing](/docs/hivemqtt/subscribing) — registering `OnMessageReceived` handlers
+* [Manual Acknowledgement](/docs/hivemqtt/how-to/manual-ack) — ack timing and Receive Maximum
+* [Lifecycle Events Reference](/docs/hivemqtt/events/Reference) — `OnMessageReceived` event args

--- a/Documentation/docs/hivemqtt/subscribing.md
+++ b/Documentation/docs/hivemqtt/subscribing.md
@@ -153,6 +153,7 @@ In this example, the message handler is defined as a lambda function that writes
 Remember, prioritizing the setup of your message handler ensures that your application is ready to process incoming messages as soon as the connection to the broker is established.
 
 * See Also: [OnMessageReceivedEventArgs.cs](https://github.com/hivemq/hivemq-mqtt-client-dotnet/blob/main/Source/HiveMQtt/Client/Events/OnMessageReceivedEventArgs.cs)
+* See Also: [Message Ordering](/docs/hivemqtt/how-to/message-ordering) — QoS 1/2 handler start order and async handler limits
 
 ## Subscribe: Multiple Topics At Once
 

--- a/Source/HiveMQtt/Client/Connection/ConnectionManagerHandlers.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManagerHandlers.cs
@@ -1,5 +1,6 @@
 namespace HiveMQtt.Client.Connection;
 
+using System;
 using HiveMQtt.Client.Exceptions;
 using HiveMQtt.Client.Internal;
 using HiveMQtt.Client.Options;
@@ -472,6 +473,8 @@ public partial class ConnectionManager
 
         // Reset the connection-ready signal for the next connect cycle
         this.ResetConnectedSignal();
+
+        await this.Client.QuiesceMessageDispatchAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
 
         // Cancel all background tasks BEFORE setting state to Disconnected
         // This prevents race conditions where tasks check state after it's set but before cancellation

--- a/Source/HiveMQtt/Client/HiveMQClient.cs
+++ b/Source/HiveMQtt/Client/HiveMQClient.cs
@@ -55,7 +55,10 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient, IBaseMQTTClient
 
         // Initialize the connection manager
         this.Connection = new ConnectionManager(this);
+        this.MessageReceivedDispatcher = new MessageReceivedDispatcher();
     }
+
+    internal MessageReceivedDispatcher MessageReceivedDispatcher { get; }
 
     /// <inheritdoc />
     public Dictionary<string, string> LocalStore { get; } = new();
@@ -119,6 +122,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient, IBaseMQTTClient
         {
             await this.SubscriptionsSemaphore.WaitAsync().ConfigureAwait(false);
             this.Subscriptions.Clear();
+            this.RefreshPerSubscriptionMessageHandlersPresent();
         }
         finally
         {
@@ -194,6 +198,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient, IBaseMQTTClient
         if (connAck.ReasonCode == ConnAckReasonCode.Success)
         {
             this.Connection.State = ConnectState.Connected;
+            this.MessageReceivedDispatcher.ResetForConnect();
 
             // Ensure connection-ready signal is set for any writers awaiting readiness
             this.Connection.SignalNotDisconnected(); // Signal that we're not disconnected (already signaled at Connecting, but safe to call again)
@@ -591,6 +596,8 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient, IBaseMQTTClient
                 _ = this.Subscriptions.RemoveAll(s => s.TopicFilter.Topic == newSubscription.TopicFilter.Topic);
                 this.Subscriptions.Add(newSubscription);
             }
+
+            this.RefreshPerSubscriptionMessageHandlersPresent();
         }
         finally
         {
@@ -742,6 +749,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient, IBaseMQTTClient
                 // remove subscriptions from client while locking them
                 await this.SubscriptionsSemaphore.WaitAsync().ConfigureAwait(false);
                 _ = this.Subscriptions.RemoveAll(subscriptionsToRemove.Contains);
+                this.RefreshPerSubscriptionMessageHandlersPresent();
             }
             finally
             {

--- a/Source/HiveMQtt/Client/HiveMQClientEvents.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientEvents.cs
@@ -16,6 +16,9 @@
 namespace HiveMQtt.Client;
 
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using HiveMQtt.Client.Events;
 using HiveMQtt.Client.Internal;
 using HiveMQtt.Client.Options;
@@ -269,15 +272,24 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
 
     internal virtual void OnMessageReceivedEventLauncher(PublishPacket packet)
     {
+        if (packet.Message.QoS is QualityOfService.AtMostOnceDelivery)
+        {
+            this.OnMessageReceivedEventLauncherQoS0(packet);
+            return;
+        }
+
+        this.OnMessageReceivedEventLauncherOrdered(packet);
+    }
+
+    private void OnMessageReceivedEventLauncherQoS0(PublishPacket packet)
+    {
         var messageHandled = false;
 
         // Get all handlers - fast path if no handlers
         if (this.OnMessageReceived != null)
         {
             Logger.Trace("OnMessageReceivedEventLauncher");
-            var eventArgs = new OnMessageReceivedEventArgs(
-                packet.Message,
-                packet.Message.QoS == QualityOfService.AtMostOnceDelivery ? null : packet.PacketIdentifier);
+            var eventArgs = new OnMessageReceivedEventArgs(packet.Message, null);
             var handlers = this.OnMessageReceived.GetInvocationList();
             foreach (var handler in handlers)
             {
@@ -294,12 +306,35 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
             messageHandled = true;
         }
 
+        if (!this.HasPerSubscriptionMessageHandlers)
+        {
+            if (!messageHandled)
+            {
+                Logger.Warn($"Lost Application Message ({packet.Message.Topic}): No global or subscription message handler found.  Register an event handler (before Subscribing) to receive all messages incoming.");
+            }
+
+            return;
+        }
+
         if (packet.Message.Topic is null)
         {
             return;
         }
 
-        // Per Subscription Event Handler
+        // Per Subscription Event Handler — resolve off the connection thread so subscribe/unsubscribe
+        // can update Subscriptions without blocking SUBACK processing.
+        _ = Task.Run(() => this.InvokeQoS0PerSubscriptionHandlers(packet));
+    }
+
+    private void InvokeQoS0PerSubscriptionHandlers(PublishPacket packet)
+    {
+        if (packet.Message.Topic is null)
+        {
+            return;
+        }
+
+        var messageHandled = false;
+
         // use ToList, so the iteration goes through a copy and changes at the list make not problems
         // otherwise it would be necessary to lock the Subscriptions with the semaphore of HiveMQClient
         List<Subscription> tempList;
@@ -315,8 +350,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
             _ = this.SubscriptionsSemaphore.Release();
         }
 
-        var matchingSubscriptions = tempList.Where(sub =>
-            sub.MessageReceivedHandler is not null &&
+        var allMatchingSubscriptions = tempList.Where(sub =>
             MatchTopic(sub.TopicFilter.Topic, packet.Message.Topic));
 
         // Check behavior setting for overlapping subscriptions
@@ -324,13 +358,11 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
 
         if (behavior == OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
         {
-            // Fire only the first matching subscription handler
-            var firstMatch = matchingSubscriptions.FirstOrDefault();
-            if (firstMatch != null)
+            // Fire only the first matching subscription handler (by subscription order)
+            var firstMatch = allMatchingSubscriptions.FirstOrDefault();
+            if (firstMatch?.MessageReceivedHandler is not null)
             {
-                var eventArgs = new OnMessageReceivedEventArgs(
-                    packet.Message,
-                    packet.Message.QoS == QualityOfService.AtMostOnceDelivery ? null : packet.PacketIdentifier);
+                var eventArgs = new OnMessageReceivedEventArgs(packet.Message, null);
 
                 _ = Task.Run(() =>
                 {
@@ -351,12 +383,12 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
         else
         {
             // Default: FireAllMatchingHandlers - fire all matching subscription handlers
+            var matchingSubscriptions = allMatchingSubscriptions.Where(sub => sub.MessageReceivedHandler is not null);
+
             // Create eventArgs only if we have subscription handlers (optimization: avoid allocation if not needed)
             if (matchingSubscriptions.Any())
             {
-                var eventArgs = new OnMessageReceivedEventArgs(
-                    packet.Message,
-                    packet.Message.QoS == QualityOfService.AtMostOnceDelivery ? null : packet.PacketIdentifier);
+                var eventArgs = new OnMessageReceivedEventArgs(packet.Message, null);
                 foreach (var subscription in matchingSubscriptions)
                 {
                     // We have a per-subscription message handler.
@@ -385,6 +417,85 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
             // We warn here about the lost message, but we don't throw an exception.
             Logger.Warn($"Lost Application Message ({packet.Message.Topic}): No global or subscription message handler found.  Register an event handler (before Subscribing) to receive all messages incoming.");
         }
+    }
+
+    private void OnMessageReceivedEventLauncherOrdered(PublishPacket packet)
+    {
+        var globalHandlers = Array.Empty<EventHandler<OnMessageReceivedEventArgs>>();
+
+        if (this.OnMessageReceived != null)
+        {
+            Logger.Trace("OnMessageReceivedEventLauncher");
+            globalHandlers = this.OnMessageReceived.GetInvocationList()
+                .Cast<EventHandler<OnMessageReceivedEventArgs>>()
+                .ToArray();
+        }
+
+        if (globalHandlers.Length == 0 && packet.Message.Topic is null)
+        {
+            Logger.Warn($"Lost Application Message ({packet.Message.Topic}): No global or subscription message handler found.  Register an event handler (before Subscribing) to receive all messages incoming.");
+            return;
+        }
+
+        var eventArgs = new OnMessageReceivedEventArgs(packet.Message, packet.PacketIdentifier);
+        var item = new MessageReceivedDispatchItem
+        {
+            Sender = this,
+            EventArgs = eventArgs,
+            GlobalHandlers = globalHandlers,
+            ResolveSubscriptionHandlers = packet.Message.Topic is null || !this.HasPerSubscriptionMessageHandlers
+                ? null
+                : () => this.ResolveOrderedSubscriptionHandlers(packet),
+        };
+
+        if (!this.MessageReceivedDispatcher.TryEnqueue(item))
+        {
+            Logger.Warn($"Dropped Application Message ({packet.Message.Topic}): message dispatch is quiescing or disposed.");
+        }
+    }
+
+    private IReadOnlyList<EventHandler<OnMessageReceivedEventArgs>> ResolveOrderedSubscriptionHandlers(PublishPacket packet)
+    {
+        if (packet.Message.Topic is null)
+        {
+            return Array.Empty<EventHandler<OnMessageReceivedEventArgs>>();
+        }
+        List<Subscription> tempList;
+        try
+        {
+            this.SubscriptionsSemaphore.Wait();
+#pragma warning disable IDE0305 // Collection initialization - ToList() is appropriate for .NET 6
+            tempList = this.Subscriptions.ToList();
+#pragma warning restore IDE0305
+        }
+        finally
+        {
+            _ = this.SubscriptionsSemaphore.Release();
+        }
+
+        var allMatchingSubscriptions = tempList.Where(sub =>
+            MatchTopic(sub.TopicFilter.Topic, packet.Message.Topic));
+
+        var behavior = this.Options.OverlappingSubscriptionBehavior;
+        var subscriptionHandlers = new List<EventHandler<OnMessageReceivedEventArgs>>();
+
+        if (behavior == OverlappingSubscriptionBehavior.FireFirstMatchingHandler)
+        {
+            var firstMatch = allMatchingSubscriptions.FirstOrDefault();
+            if (firstMatch?.MessageReceivedHandler is not null)
+            {
+                subscriptionHandlers.Add(firstMatch.MessageReceivedHandler);
+            }
+        }
+        else
+        {
+            foreach (var subscription in allMatchingSubscriptions.Where(sub => sub.MessageReceivedHandler is not null))
+            {
+                subscriptionHandlers.Add(subscription.MessageReceivedHandler!);
+            }
+        }
+
+        return subscriptionHandlers;
     }
 
     /* ========================================================================================= */
@@ -1019,4 +1130,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
     void IBaseMQTTClient.OnPingReqSentEventLauncher(PingReqPacket packet) => this.OnPingReqSentEventLauncher(packet);
 
     void IBaseMQTTClient.AfterDisconnectEventLauncher(bool clean) => this.AfterDisconnectEventLauncher(clean);
+
+    Task IBaseMQTTClient.QuiesceMessageDispatchAsync(TimeSpan timeout) =>
+        this.MessageReceivedDispatcher.QuiesceAsync(timeout);
 }

--- a/Source/HiveMQtt/Client/HiveMQClientUtil.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientUtil.cs
@@ -16,13 +16,26 @@
 namespace HiveMQtt.Client;
 
 using System;
+using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using HiveMQtt.MQTT5.Types;
 
 /// <inheritdoc />
 public partial class HiveMQClient : IDisposable, IHiveMQClient
 {
     private bool disposed;
+
+    private int perSubscriptionMessageHandlersPresent;
+
+    internal bool HasPerSubscriptionMessageHandlers =>
+        Volatile.Read(ref this.perSubscriptionMessageHandlersPresent) != 0;
+
+    private void RefreshPerSubscriptionMessageHandlersPresent()
+    {
+        this.perSubscriptionMessageHandlersPresent =
+            this.Subscriptions.Any(s => s.MessageReceivedHandler is not null) ? 1 : 0;
+    }
 
     /// <summary>
     /// Validates whether a subscription already exists.
@@ -205,6 +218,7 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
 
                 // Dispose the connection manager
                 this.Connection?.Dispose();
+                this.MessageReceivedDispatcher?.Dispose();
             }
 
             // Call the appropriate methods to clean up

--- a/Source/HiveMQtt/Client/RawClient.cs
+++ b/Source/HiveMQtt/Client/RawClient.cs
@@ -56,7 +56,10 @@ public partial class RawClient : IDisposable, IRawClient, IBaseMQTTClient
 
         // Initialize the connection manager
         this.Connection = new ConnectionManager(this);
+        this.MessageReceivedDispatcher = new MessageReceivedDispatcher();
     }
+
+    internal MessageReceivedDispatcher MessageReceivedDispatcher { get; }
 
     /// <inheritdoc />
     public Dictionary<string, string> LocalStore { get; } = new();
@@ -176,6 +179,7 @@ public partial class RawClient : IDisposable, IRawClient, IBaseMQTTClient
         if (connAck.ReasonCode == ConnAckReasonCode.Success)
         {
             this.Connection.State = ConnectState.Connected;
+            this.MessageReceivedDispatcher.ResetForConnect();
 
             // Ensure connection-ready signal is set for any writers awaiting readiness
             this.Connection.SignalNotDisconnected();
@@ -700,7 +704,31 @@ public partial class RawClient : IDisposable, IRawClient, IBaseMQTTClient
         {
             if (disposing)
             {
+                if (this.Connection?.State == Internal.ConnectState.Connected)
+                {
+                    Logger.Trace("RawClient Dispose: Disconnecting connected client.");
+                    try
+                    {
+                        var disconnectTask = Task.Run(async () => await this.DisconnectAsync().ConfigureAwait(false));
+                        try
+                        {
+#pragma warning disable VSTHRD002
+                            disconnectTask.WaitAsync(TimeSpan.FromMilliseconds(5000)).GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002
+                        }
+                        catch (TimeoutException)
+                        {
+                            Logger.Warn("Disconnect operation timed out during RawClient dispose");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Warn($"Error disconnecting RawClient during dispose: {ex.Message}");
+                    }
+                }
+
                 this.Connection?.Dispose();
+                this.MessageReceivedDispatcher?.Dispose();
             }
 
             this.disposed = true;

--- a/Source/HiveMQtt/Client/RawClientEvents.cs
+++ b/Source/HiveMQtt/Client/RawClientEvents.cs
@@ -16,6 +16,7 @@
 namespace HiveMQtt.Client;
 
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using HiveMQtt.Client.Events;
 using HiveMQtt.Client.Internal;
@@ -273,13 +274,15 @@ public partial class RawClient : IDisposable, IRawClient, IBaseMQTTClient
 
     internal virtual void OnMessageReceivedEventLauncher(PublishPacket packet)
     {
-        // RawClient does not maintain subscription state, so we simply fire the event if handlers are registered
-        if (this.OnMessageReceived != null)
+        if (this.OnMessageReceived == null)
+        {
+            return;
+        }
+
+        if (packet.Message.QoS is QualityOfService.AtMostOnceDelivery)
         {
             Logger.Trace("OnMessageReceivedEventLauncher");
-            var eventArgs = new OnMessageReceivedEventArgs(
-                packet.Message,
-                packet.Message.QoS == QualityOfService.AtMostOnceDelivery ? null : packet.PacketIdentifier);
+            var eventArgs = new OnMessageReceivedEventArgs(packet.Message, null);
             var handlers = this.OnMessageReceived.GetInvocationList();
             foreach (var handler in handlers)
             {
@@ -292,6 +295,30 @@ public partial class RawClient : IDisposable, IRawClient, IBaseMQTTClient
                         }
                     }, TaskScheduler.Default);
             }
+
+            return;
+        }
+
+        Logger.Trace("OnMessageReceivedEventLauncher");
+        var globalHandlers = this.OnMessageReceived.GetInvocationList()
+            .Cast<EventHandler<OnMessageReceivedEventArgs>>()
+            .ToArray();
+        if (globalHandlers.Length == 0)
+        {
+            return;
+        }
+
+        var orderedEventArgs = new OnMessageReceivedEventArgs(packet.Message, packet.PacketIdentifier);
+        var item = new MessageReceivedDispatchItem
+        {
+            Sender = this,
+            EventArgs = orderedEventArgs,
+            GlobalHandlers = globalHandlers,
+        };
+
+        if (!this.MessageReceivedDispatcher.TryEnqueue(item))
+        {
+            Logger.Warn($"Dropped Application Message ({packet.Message.Topic}): message dispatch is quiescing or disposed.");
         }
     }
 
@@ -927,4 +954,7 @@ public partial class RawClient : IDisposable, IRawClient, IBaseMQTTClient
     void IBaseMQTTClient.OnPingReqSentEventLauncher(PingReqPacket packet) => this.OnPingReqSentEventLauncher(packet);
 
     void IBaseMQTTClient.AfterDisconnectEventLauncher(bool clean) => this.AfterDisconnectEventLauncher(clean);
+
+    Task IBaseMQTTClient.QuiesceMessageDispatchAsync(TimeSpan timeout) =>
+        this.MessageReceivedDispatcher.QuiesceAsync(timeout);
 }

--- a/Source/HiveMQtt/Client/internal/IBaseMQTTClient.cs
+++ b/Source/HiveMQtt/Client/internal/IBaseMQTTClient.cs
@@ -15,6 +15,7 @@
  */
 namespace HiveMQtt.Client.Internal;
 
+using System;
 using System.Threading.Tasks;
 using HiveMQtt.Client.Options;
 using HiveMQtt.MQTT5.Packets;
@@ -50,6 +51,13 @@ internal interface IBaseMQTTClient
     /// <param name="options">The disconnect options.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     public Task<bool> DisconnectAsync(DisconnectOptions? options = null);
+
+    /// <summary>
+    /// Quiesces the ordered message dispatch queue: drop pending handlers and wait for in-flight handler.
+    /// </summary>
+    /// <param name="timeout">Maximum time to wait for the in-flight handler.</param>
+    /// <returns>A task that completes when quiesce finishes or times out.</returns>
+    public Task QuiesceMessageDispatchAsync(TimeSpan timeout);
 
     // Event launcher methods
     public void OnConnAckReceivedEventLauncher(ConnAckPacket packet);

--- a/Source/HiveMQtt/Client/internal/MessageReceivedDispatchItem.cs
+++ b/Source/HiveMQtt/Client/internal/MessageReceivedDispatchItem.cs
@@ -1,0 +1,23 @@
+namespace HiveMQtt.Client.Internal;
+
+using System;
+using System.Collections.Generic;
+using HiveMQtt.Client.Events;
+
+/// <summary>
+/// A snapshot of handlers to invoke for one received publish (QoS 1 or 2).
+/// </summary>
+internal sealed class MessageReceivedDispatchItem
+{
+    public object Sender { get; init; } = null!;
+
+    public OnMessageReceivedEventArgs EventArgs { get; init; } = null!;
+
+    public IReadOnlyList<EventHandler<OnMessageReceivedEventArgs>> GlobalHandlers { get; init; } =
+        Array.Empty<EventHandler<OnMessageReceivedEventArgs>>();
+
+    /// <summary>
+    /// Gets an optional resolver for per-subscription handlers, invoked on the dispatch consumer thread.
+    /// </summary>
+    public Func<IReadOnlyList<EventHandler<OnMessageReceivedEventArgs>>>? ResolveSubscriptionHandlers { get; init; }
+}

--- a/Source/HiveMQtt/Client/internal/MessageReceivedDispatcher.cs
+++ b/Source/HiveMQtt/Client/internal/MessageReceivedDispatcher.cs
@@ -1,0 +1,193 @@
+namespace HiveMQtt.Client.Internal;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HiveMQtt.Client.Events;
+
+/// <summary>
+/// Serializes QoS 1/2 <see cref="HiveMQClient.OnMessageReceived"/> handler invocation in FIFO order.
+/// </summary>
+internal sealed class MessageReceivedDispatcher : IDisposable
+{
+    private static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+
+    private static readonly AsyncLocal<bool> IsDispatchThread = new();
+
+    private readonly AwaitableQueueX<MessageReceivedDispatchItem> queue = new();
+    private readonly CancellationTokenSource cts = new();
+    private readonly Task consumerTask;
+    private int quiescing;
+    private int disposed;
+    private int inFlight;
+
+    public MessageReceivedDispatcher() =>
+        this.consumerTask = Task.Run(() => this.ConsumerLoopAsync(this.cts.Token));
+
+    /// <summary>
+    /// Gets a value indicating whether the current thread is executing a message dispatch handler.
+    /// </summary>
+    internal static bool IsOnDispatchThread => IsDispatchThread.Value;
+
+    /// <summary>
+    /// Resets quiesce state so handlers can be enqueued again after a successful connect.
+    /// </summary>
+    public void ResetForConnect()
+    {
+        if (Volatile.Read(ref this.disposed) == 0)
+        {
+            Interlocked.Exchange(ref this.quiescing, 0);
+        }
+    }
+
+    /// <summary>
+    /// Enqueues a dispatch item. Returns false when quiescing, disposed, or no handlers are registered.
+    /// </summary>
+    /// <param name="item">The handlers and event args to dispatch.</param>
+    /// <returns><see langword="true"/> when the item was enqueued; otherwise <see langword="false"/>.</returns>
+    public bool TryEnqueue(MessageReceivedDispatchItem item)
+    {
+        if (Volatile.Read(ref this.quiescing) != 0 || Volatile.Read(ref this.disposed) != 0)
+        {
+            return false;
+        }
+
+        if (item.GlobalHandlers.Count == 0 && item.ResolveSubscriptionHandlers is null)
+        {
+            return false;
+        }
+
+        this.queue.Enqueue(item);
+        return true;
+    }
+
+    /// <summary>
+    /// Stops accepting new items, drops pending items, and waits for the in-flight handler to finish.
+    /// When called from a dispatch handler thread, pending items are dropped but this method does not
+    /// wait for the current handler (avoids self-deadlock).
+    /// </summary>
+    /// <param name="timeout">Maximum time to wait for the in-flight handler.</param>
+    /// <returns>A task that completes when quiesce finishes or times out.</returns>
+    public async Task QuiesceAsync(TimeSpan timeout)
+    {
+        Interlocked.Exchange(ref this.quiescing, 1);
+        this.queue.Clear();
+
+        if (IsDispatchThread.Value)
+        {
+            return;
+        }
+
+        var deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        while (Interlocked.CompareExchange(ref this.inFlight, 0, 0) > 0)
+        {
+            if (Environment.TickCount64 >= deadline)
+            {
+                Logger.Warn("MessageReceivedDispatcher quiesce timed out waiting for in-flight handler.");
+                break;
+            }
+
+            await Task.Delay(10).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref this.disposed, 1) != 0)
+        {
+            return;
+        }
+
+        Interlocked.Exchange(ref this.quiescing, 1);
+        this.queue.Clear();
+        this.cts.Cancel();
+
+        try
+        {
+#pragma warning disable VSTHRD002 // Dispose must synchronously stop the consumer task
+            this.consumerTask.Wait(TimeSpan.FromSeconds(5));
+#pragma warning restore VSTHRD002
+        }
+        catch (Exception ex)
+        {
+            Logger.Warn($"MessageReceivedDispatcher dispose wait failed: {ex.Message}");
+        }
+
+        this.cts.Dispose();
+        this.queue.Dispose();
+    }
+
+    private static void DispatchItem(MessageReceivedDispatchItem item)
+    {
+        var subscriptionHandlers =
+            item.ResolveSubscriptionHandlers?.Invoke() ?? Array.Empty<EventHandler<OnMessageReceivedEventArgs>>();
+
+        if (item.GlobalHandlers.Count == 0 && subscriptionHandlers.Count == 0)
+        {
+            Logger.Warn(
+                $"Lost Application Message ({item.EventArgs.PublishMessage.Topic}): No global or subscription message handler found.  Register an event handler (before Subscribing) to receive all messages incoming.");
+            return;
+        }
+
+        foreach (var handler in item.GlobalHandlers)
+        {
+            try
+            {
+                handler(item.Sender, item.EventArgs);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error($"OnMessageReceived Handler exception: {ex.Message}");
+            }
+        }
+
+        foreach (var handler in subscriptionHandlers)
+        {
+            try
+            {
+                handler(item.Sender, item.EventArgs);
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(
+                    $"per-subscription MessageReceivedEventLauncher faulted ({item.EventArgs.PublishMessage.Topic}): {ex.Message}");
+            }
+        }
+    }
+
+    private async Task ConsumerLoopAsync(CancellationToken cancellationToken)
+    {
+        IsDispatchThread.Value = true;
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                MessageReceivedDispatchItem item;
+                try
+                {
+                    item = await this.queue.DequeueAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+
+                Interlocked.Increment(ref this.inFlight);
+                try
+                {
+                    DispatchItem(item);
+                }
+                finally
+                {
+                    Interlocked.Decrement(ref this.inFlight);
+                }
+            }
+        }
+        finally
+        {
+            IsDispatchThread.Value = false;
+        }
+    }
+}

--- a/Source/HiveMQtt/MQTT5/Types/SubscriptionBehavior.cs
+++ b/Source/HiveMQtt/MQTT5/Types/SubscriptionBehavior.cs
@@ -45,5 +45,5 @@ public enum OverlappingSubscriptionBehavior
     /// handler (in the order they were added) will fire for a message that matches all 3 subscriptions.
     /// The global OnMessageReceived event is not affected by this setting and always fires.
     /// </remarks>
-    FireFirstMatchingHandler
+    FireFirstMatchingHandler,
 }

--- a/Tests/HiveMQtt.Test/HiveMQClient/MessageOrderingTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/MessageOrderingTest.cs
@@ -1,0 +1,384 @@
+namespace HiveMQtt.Test.HiveMQClient;
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using HiveMQtt.Client;
+using HiveMQtt.Client.Events;
+using HiveMQtt.Client.Options;
+using HiveMQtt.MQTT5.Types;
+using Xunit;
+
+[Collection("Broker")]
+public class MessageOrderingTest
+{
+    [Fact]
+    public async Task QoS1_GlobalHandler_PreservesInvocationOrderAsync()
+    {
+        var testTopic = $"tests/MessageOrdering/QoS1Global/{Guid.NewGuid():N}";
+        using var subscriber = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderSubQoS1_{Guid.NewGuid():N}")
+            .Build());
+        using var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderPubQoS1_{Guid.NewGuid():N}")
+            .Build());
+
+        var seen = await MessageOrderingTestHelper.RunOrderedReceiveTestAsync(
+            subscriber,
+            publisher,
+            testTopic,
+            QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        MessageOrderingTestHelper.AssertSequentialOrder(seen);
+    }
+
+    [Fact]
+    public async Task QoS2_GlobalHandler_PreservesInvocationOrderAsync()
+    {
+        var testTopic = $"tests/MessageOrdering/QoS2Global/{Guid.NewGuid():N}";
+        using var subscriber = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderSubQoS2_{Guid.NewGuid():N}")
+            .Build());
+        using var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderPubQoS2_{Guid.NewGuid():N}")
+            .Build());
+
+        var seen = await MessageOrderingTestHelper.RunOrderedReceiveTestAsync(
+            subscriber,
+            publisher,
+            testTopic,
+            QualityOfService.ExactlyOnceDelivery,
+            settleMs: 5000).ConfigureAwait(false);
+
+        MessageOrderingTestHelper.AssertSequentialOrder(seen);
+    }
+
+    [Fact]
+    public async Task QoS1_PerSubscriptionHandler_PreservesInvocationOrderAsync()
+    {
+        var testTopic = $"tests/MessageOrdering/QoS1PerSub/{Guid.NewGuid():N}";
+        using var subscriber = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderSubPerSub_{Guid.NewGuid():N}")
+            .Build());
+        using var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderPubPerSub_{Guid.NewGuid():N}")
+            .Build());
+
+        var seen = new List<int>();
+        var seenLock = new object();
+        var receivedCount = 0;
+
+        var subscribeOptions = new SubscribeOptionsBuilder()
+            .WithSubscription(testTopic, QualityOfService.AtLeastOnceDelivery, messageReceivedHandler: (_, args) =>
+            {
+                var idx = int.Parse(args.PublishMessage.PayloadAsString ?? "-1", System.Globalization.CultureInfo.InvariantCulture);
+                Thread.Sleep(idx % 3 == 0 ? 5 : 1);
+                lock (seenLock)
+                {
+                    seen.Add(idx);
+                    receivedCount++;
+                }
+            })
+            .Build();
+
+        await subscriber.ConnectAsync().ConfigureAwait(false);
+        await publisher.ConnectAsync().ConfigureAwait(false);
+        await subscriber.SubscribeAsync(subscribeOptions).ConfigureAwait(false);
+
+        for (var i = 0; i < MessageOrderingTestHelper.DefaultMessageCount; i++)
+        {
+            await publisher.PublishAsync(testTopic, i.ToString(System.Globalization.CultureInfo.InvariantCulture), QualityOfService.AtLeastOnceDelivery)
+                .ConfigureAwait(false);
+        }
+
+        var deadline = Environment.TickCount64 + 3000;
+        while (receivedCount < MessageOrderingTestHelper.DefaultMessageCount && Environment.TickCount64 < deadline)
+        {
+            await Task.Delay(50).ConfigureAwait(false);
+        }
+
+        await subscriber.DisconnectAsync().ConfigureAwait(false);
+        await publisher.DisconnectAsync().ConfigureAwait(false);
+
+        Assert.Equal(MessageOrderingTestHelper.DefaultMessageCount, receivedCount);
+        MessageOrderingTestHelper.AssertSequentialOrder(seen);
+    }
+
+    [Fact]
+    public async Task QoS1_ManualAck_GlobalHandler_PreservesInvocationOrderAsync()
+    {
+        var testTopic = $"tests/MessageOrdering/QoS1ManualAck/{Guid.NewGuid():N}";
+        using var subscriber = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderSubManual_{Guid.NewGuid():N}")
+            .WithManualAck(true)
+            .Build());
+        using var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderPubManual_{Guid.NewGuid():N}")
+            .Build());
+
+        var seen = await MessageOrderingTestHelper.RunOrderedReceiveTestAsync(
+            subscriber,
+            publisher,
+            testTopic,
+            QualityOfService.AtLeastOnceDelivery,
+            onMessageReceived: args =>
+            {
+                if (args.PacketIdentifier.HasValue)
+                {
+                    subscriber.AckAsync(args).GetAwaiter().GetResult();
+                }
+            },
+            messageCount: 20,
+            settleMs: 5000).ConfigureAwait(false);
+
+        MessageOrderingTestHelper.AssertSequentialOrder(seen, 20);
+    }
+
+    [Fact]
+    public async Task QoS1_GlobalBeforePerSubscription_OnSameMessageAsync()
+    {
+        var testTopic = $"tests/MessageOrdering/GlobalBeforePerSub/{Guid.NewGuid():N}";
+        using var subscriber = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderGlobalFirst_{Guid.NewGuid():N}")
+            .Build());
+        using var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderPubGlobalFirst_{Guid.NewGuid():N}")
+            .Build());
+
+        var order = new List<string>();
+        var orderLock = new object();
+        var received = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        subscriber.OnMessageReceived += (_, _) =>
+        {
+            lock (orderLock)
+            {
+                order.Add("global");
+            }
+        };
+
+        var subscribeOptions = new SubscribeOptionsBuilder()
+            .WithSubscription(testTopic, QualityOfService.AtLeastOnceDelivery, messageReceivedHandler: (_, _) =>
+            {
+                lock (orderLock)
+                {
+                    order.Add("persub");
+                    if (order.Count == 2)
+                    {
+                        received.TrySetResult(true);
+                    }
+                }
+            })
+            .Build();
+
+        await subscriber.ConnectAsync().ConfigureAwait(false);
+        await publisher.ConnectAsync().ConfigureAwait(false);
+        await subscriber.SubscribeAsync(subscribeOptions).ConfigureAwait(false);
+        await publisher.PublishAsync(testTopic, "x", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        await received.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+        await subscriber.DisconnectAsync().ConfigureAwait(false);
+        await publisher.DisconnectAsync().ConfigureAwait(false);
+
+        Assert.Equal(new[] { "global", "persub" }, order);
+    }
+
+    [Fact]
+    public async Task QoS1_AsyncHandler_PreservesInvocationStartOrderAsync()
+    {
+        var testTopic = $"tests/MessageOrdering/AsyncStartOrder/{Guid.NewGuid():N}";
+        using var subscriber = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderAsyncStart_{Guid.NewGuid():N}")
+            .Build());
+        using var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderPubAsyncStart_{Guid.NewGuid():N}")
+            .Build());
+
+        var startOrder = new List<int>();
+        var completionOrder = new List<int>();
+        var lockObj = new object();
+        var done = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        subscriber.OnMessageReceived += async (_, args) =>
+        {
+            var idx = int.Parse(args.PublishMessage.PayloadAsString ?? "-1", System.Globalization.CultureInfo.InvariantCulture);
+            lock (lockObj)
+            {
+                startOrder.Add(idx);
+            }
+
+            await Task.Delay(idx == 0 ? 50 : 1).ConfigureAwait(false);
+
+            lock (lockObj)
+            {
+                completionOrder.Add(idx);
+                if (completionOrder.Count == 2)
+                {
+                    done.TrySetResult(true);
+                }
+            }
+        };
+
+        await subscriber.ConnectAsync().ConfigureAwait(false);
+        await publisher.ConnectAsync().ConfigureAwait(false);
+        await subscriber.SubscribeAsync(testTopic, QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        await publisher.PublishAsync(testTopic, "0", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+        await publisher.PublishAsync(testTopic, "1", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        await done.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+
+        await subscriber.DisconnectAsync().ConfigureAwait(false);
+        await publisher.DisconnectAsync().ConfigureAwait(false);
+
+        Assert.Equal(new[] { 0, 1 }, startOrder);
+    }
+
+    [Fact]
+    public async Task ReentrantPublish_FromHandler_DoesNotDeadlockAsync()
+    {
+        await RunReentrancyTestAsync(async (subscriber, publisher, testTopic, ackTopic) =>
+        {
+            await publisher.PublishAsync(ackTopic, "done", QualityOfService.AtMostOnceDelivery).ConfigureAwait(false);
+        }).ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task ReentrantSubscribe_FromHandler_DoesNotDeadlockAsync()
+    {
+        var testTopic = $"tests/MessageOrdering/ReentrantSubscribe/{Guid.NewGuid():N}";
+        var newTopic = $"tests/MessageOrdering/ReentrantSubscribeNew/{Guid.NewGuid():N}";
+        using var subscriber = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderReentSub_{Guid.NewGuid():N}")
+            .Build());
+        using var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderPubReentSub_{Guid.NewGuid():N}")
+            .Build());
+
+        var subscribeCompleted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        subscriber.OnMessageReceived += (_, args) =>
+        {
+            if (args.PublishMessage.Topic != testTopic)
+            {
+                return;
+            }
+
+            _ = Task.Run(async () =>
+            {
+                await subscriber.SubscribeAsync(newTopic, QualityOfService.AtMostOnceDelivery).ConfigureAwait(false);
+                subscribeCompleted.TrySetResult(true);
+            });
+        };
+
+        await subscriber.ConnectAsync().ConfigureAwait(false);
+        await publisher.ConnectAsync().ConfigureAwait(false);
+        await subscriber.SubscribeAsync(testTopic, QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+        await publisher.PublishAsync(testTopic, "trigger", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        await subscribeCompleted.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+
+        await subscriber.DisconnectAsync().ConfigureAwait(false);
+        await publisher.DisconnectAsync().ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task ReentrantDisconnect_FromHandler_DoesNotDeadlockAsync()
+    {
+        var testTopic = $"tests/MessageOrdering/ReentrantDisconnect/{Guid.NewGuid():N}";
+        using var subscriber = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderReentDisc_{Guid.NewGuid():N}")
+            .Build());
+        using var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderPubReentDisc_{Guid.NewGuid():N}")
+            .Build());
+
+        var disconnected = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        subscriber.OnMessageReceived += async (_, _) =>
+        {
+            await subscriber.DisconnectAsync().ConfigureAwait(false);
+            disconnected.TrySetResult(true);
+        };
+
+        await subscriber.ConnectAsync().ConfigureAwait(false);
+        await publisher.ConnectAsync().ConfigureAwait(false);
+        await subscriber.SubscribeAsync(testTopic, QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+        await publisher.PublishAsync(testTopic, "trigger", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        await disconnected.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+        await publisher.DisconnectAsync().ConfigureAwait(false);
+    }
+
+    [Fact]
+    public async Task ReentrantAckAsync_FromHandler_DoesNotDeadlockAsync()
+    {
+        var testTopic = $"tests/MessageOrdering/ReentrantAck/{Guid.NewGuid():N}";
+        using var subscriber = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderReentAck_{Guid.NewGuid():N}")
+            .WithManualAck(true)
+            .Build());
+        using var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderPubReentAck_{Guid.NewGuid():N}")
+            .Build());
+
+        var acked = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        subscriber.OnMessageReceived += async (_, args) =>
+        {
+            await subscriber.AckAsync(args).ConfigureAwait(false);
+            acked.TrySetResult(true);
+        };
+
+        await subscriber.ConnectAsync().ConfigureAwait(false);
+        await publisher.ConnectAsync().ConfigureAwait(false);
+        await subscriber.SubscribeAsync(testTopic, QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+        await publisher.PublishAsync(testTopic, "1", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        await acked.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+
+        await subscriber.DisconnectAsync().ConfigureAwait(false);
+        await publisher.DisconnectAsync().ConfigureAwait(false);
+    }
+
+    private static async Task RunReentrancyTestAsync(Func<HiveMQClient, HiveMQClient, string, string, Task> handlerAction)
+    {
+        var testTopic = $"tests/MessageOrdering/Reentrant/{Guid.NewGuid():N}";
+        var ackTopic = $"tests/MessageOrdering/ReentrantAck/{Guid.NewGuid():N}";
+        using var subscriber = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderReent_{Guid.NewGuid():N}")
+            .Build());
+        using var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"MsgOrderPubReent_{Guid.NewGuid():N}")
+            .Build());
+
+        var completed = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        subscriber.OnMessageReceived += async (_, args) =>
+        {
+            if (args.PublishMessage.Topic == ackTopic)
+            {
+                completed.TrySetResult(true);
+                return;
+            }
+
+            if (args.PublishMessage.Topic == testTopic)
+            {
+                await handlerAction(subscriber, publisher, testTopic, ackTopic).ConfigureAwait(false);
+            }
+        };
+
+        await subscriber.ConnectAsync().ConfigureAwait(false);
+        await publisher.ConnectAsync().ConfigureAwait(false);
+        await subscriber.SubscribeAsync(testTopic, QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+        await subscriber.SubscribeAsync(ackTopic, QualityOfService.AtMostOnceDelivery).ConfigureAwait(false);
+        await publisher.PublishAsync(testTopic, "trigger", QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+
+        await subscriber.DisconnectAsync().ConfigureAwait(false);
+        await publisher.DisconnectAsync().ConfigureAwait(false);
+    }
+}

--- a/Tests/HiveMQtt.Test/HiveMQClient/MessageOrderingTestHelper.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/MessageOrderingTestHelper.cs
@@ -1,0 +1,75 @@
+namespace HiveMQtt.Test.HiveMQClient;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HiveMQtt.Client;
+using HiveMQtt.Client.Events;
+using HiveMQtt.MQTT5.ReasonCodes;
+using HiveMQtt.MQTT5.Types;
+using Xunit;
+
+internal static class MessageOrderingTestHelper
+{
+    internal const int DefaultMessageCount = 50;
+
+    internal static async Task<List<int>> RunOrderedReceiveTestAsync(
+        HiveMQClient subscriber,
+        HiveMQClient publisher,
+        string testTopic,
+        QualityOfService qos,
+        Action<OnMessageReceivedEventArgs>? onMessageReceived = null,
+        int messageCount = DefaultMessageCount,
+        int settleMs = 2000)
+    {
+        var seen = new List<int>();
+        var seenLock = new object();
+        var receivedCount = 0;
+
+        subscriber.OnMessageReceived += (_, args) =>
+        {
+            var idx = int.Parse(args.PublishMessage.PayloadAsString ?? "-1", System.Globalization.CultureInfo.InvariantCulture);
+            Thread.Sleep(idx % 3 == 0 ? 5 : 1);
+            onMessageReceived?.Invoke(args);
+            lock (seenLock)
+            {
+                seen.Add(idx);
+                receivedCount++;
+            }
+        };
+
+        var subConnect = await subscriber.ConnectAsync().ConfigureAwait(false);
+        Assert.True(subConnect.ReasonCode == ConnAckReasonCode.Success);
+
+        var pubConnect = await publisher.ConnectAsync().ConfigureAwait(false);
+        Assert.True(pubConnect.ReasonCode == ConnAckReasonCode.Success);
+
+        await subscriber.SubscribeAsync(testTopic, qos).ConfigureAwait(false);
+
+        for (var i = 0; i < messageCount; i++)
+        {
+            await publisher.PublishAsync(testTopic, i.ToString(System.Globalization.CultureInfo.InvariantCulture), qos)
+                .ConfigureAwait(false);
+        }
+
+        var deadline = Environment.TickCount64 + settleMs;
+        while (receivedCount < messageCount && Environment.TickCount64 < deadline)
+        {
+            await Task.Delay(50).ConfigureAwait(false);
+        }
+
+        await subscriber.DisconnectAsync().ConfigureAwait(false);
+        await publisher.DisconnectAsync().ConfigureAwait(false);
+
+        Assert.Equal(messageCount, receivedCount);
+        return seen;
+    }
+
+    internal static void AssertSequentialOrder(IReadOnlyList<int> seen, int messageCount = DefaultMessageCount)
+    {
+        var expected = Enumerable.Range(0, messageCount).ToList();
+        Assert.Equal(expected, seen);
+    }
+}

--- a/Tests/HiveMQtt.Test/RawClient/RawClientMessageOrderingTest.cs
+++ b/Tests/HiveMQtt.Test/RawClient/RawClientMessageOrderingTest.cs
@@ -1,0 +1,63 @@
+namespace HiveMQtt.Test.RawClient;
+
+using System;
+using System.Threading.Tasks;
+using HiveMQtt.Client;
+using HiveMQtt.Client.Options;
+using HiveMQtt.MQTT5.Types;
+using HiveMQtt.Test.HiveMQClient;
+using Xunit;
+
+[Collection("Broker")]
+public class RawClientMessageOrderingTest
+{
+    [Fact]
+    public async Task QoS1_GlobalHandler_PreservesInvocationOrderAsync()
+    {
+        var testTopic = $"tests/RawClientMessageOrdering/QoS1/{Guid.NewGuid():N}";
+        using var subscriber = new RawClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"RawMsgOrderSub_{Guid.NewGuid():N}")
+            .Build());
+        using var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId($"RawMsgOrderPub_{Guid.NewGuid():N}")
+            .Build());
+
+        var seen = new List<int>();
+        var seenLock = new object();
+        var receivedCount = 0;
+
+        subscriber.OnMessageReceived += (_, args) =>
+        {
+            var idx = int.Parse(args.PublishMessage.PayloadAsString ?? "-1", System.Globalization.CultureInfo.InvariantCulture);
+            Thread.Sleep(idx % 3 == 0 ? 5 : 1);
+            lock (seenLock)
+            {
+                seen.Add(idx);
+                receivedCount++;
+            }
+        };
+
+        await subscriber.ConnectAsync().ConfigureAwait(false);
+        await publisher.ConnectAsync().ConfigureAwait(false);
+
+        await subscriber.SubscribeAsync(testTopic, QualityOfService.AtLeastOnceDelivery).ConfigureAwait(false);
+
+        for (var i = 0; i < MessageOrderingTestHelper.DefaultMessageCount; i++)
+        {
+            await publisher.PublishAsync(testTopic, i.ToString(System.Globalization.CultureInfo.InvariantCulture), QualityOfService.AtLeastOnceDelivery)
+                .ConfigureAwait(false);
+        }
+
+        var deadline = Environment.TickCount64 + 3000;
+        while (receivedCount < MessageOrderingTestHelper.DefaultMessageCount && Environment.TickCount64 < deadline)
+        {
+            await Task.Delay(50).ConfigureAwait(false);
+        }
+
+        await subscriber.DisconnectAsync().ConfigureAwait(false);
+        await publisher.DisconnectAsync().ConfigureAwait(false);
+
+        Assert.Equal(MessageOrderingTestHelper.DefaultMessageCount, receivedCount);
+        MessageOrderingTestHelper.AssertSequentialOrder(seen);
+    }
+}


### PR DESCRIPTION
## Summary

QoS 1/2 `OnMessageReceived` handlers now run through a per-client FIFO dispatcher so invocation order matches broker receive order (MQTT 5 §4.6). QoS 0 stays on `Task.Run`. Global handlers still fire before per-subscription handlers.

Also fixes a connection-thread deadlock that caused `ThreadSafeSubscribeUnsubscribeTest` SUBACK timeouts under heavy concurrent subscribe/publish load.

## Test plan

- [x] `MessageOrderingTest` (HiveMQClient + RawClient)
- [x] `ThreadSafeSubscribeUnsubscribeTest`
- [x] `ManualAckTest`, `OverlappingSubscriptionTest`

Fixes #336