### PR TITLE
Fix build analyzer warnings

### DIFF
--- a/Source/HiveMQtt.Sparkplug/EdgeNode/SparkplugEdgeNode.cs
+++ b/Source/HiveMQtt.Sparkplug/EdgeNode/SparkplugEdgeNode.cs
@@ -346,7 +346,9 @@ public sealed class SparkplugEdgeNode : IDisposable
     public Task<PublishResult> PublishNodeDataAsync(IEnumerable<Payload.Types.Metric> metrics, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(metrics);
+#pragma warning disable IDE0305 // Collection initialization - ToList() is appropriate for .NET 6
         var metricList = metrics as IList<Payload.Types.Metric> ?? metrics.ToList();
+#pragma warning restore IDE0305
         if (metricList.Count == 0)
         {
             throw new ArgumentException("At least one metric is required.", nameof(metrics));
@@ -437,7 +439,9 @@ public sealed class SparkplugEdgeNode : IDisposable
     {
         SparkplugIdValidator.ValidateDeviceId(deviceId, nameof(deviceId), this.options.StrictIdentifierValidation);
         ArgumentNullException.ThrowIfNull(metrics);
+#pragma warning disable IDE0305 // Collection initialization - ToList() is appropriate for .NET 6
         var metricList = metrics as IList<Payload.Types.Metric> ?? metrics.ToList();
+#pragma warning restore IDE0305
         if (metricList.Count == 0)
         {
             throw new ArgumentException("At least one metric is required.", nameof(metrics));

--- a/Source/HiveMQtt.Sparkplug/HostApplication/SparkplugStatePayload.cs
+++ b/Source/HiveMQtt.Sparkplug/HostApplication/SparkplugStatePayload.cs
@@ -77,7 +77,7 @@ public sealed class SparkplugStatePayload
     /// <param name="timestampMs">Timestamp in milliseconds since Unix epoch (0 for LWT).</param>
     /// <returns>A new STATE payload with online=false.</returns>
     public static SparkplugStatePayload CreateOffline(long timestampMs = 0) =>
-        new SparkplugStatePayload(online: false, timestampMs);
+        new(online: false, timestampMs);
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SparkplugStatePayload"/> class.

--- a/Source/HiveMQtt/Client/HiveMQClientEvents.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientEvents.cs
@@ -421,14 +421,18 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
 
     private void OnMessageReceivedEventLauncherOrdered(PublishPacket packet)
     {
+#pragma warning disable IDE0301 // Collection initialization - Array.Empty is required for StyleCop SA1010
         var globalHandlers = Array.Empty<EventHandler<OnMessageReceivedEventArgs>>();
+#pragma warning restore IDE0301
 
         if (this.OnMessageReceived != null)
         {
             Logger.Trace("OnMessageReceivedEventLauncher");
+#pragma warning disable IDE0305 // Collection initialization - ToArray() is appropriate for .NET 6
             globalHandlers = this.OnMessageReceived.GetInvocationList()
                 .Cast<EventHandler<OnMessageReceivedEventArgs>>()
                 .ToArray();
+#pragma warning restore IDE0305
         }
 
         if (globalHandlers.Length == 0 && packet.Message.Topic is null)
@@ -458,8 +462,11 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
     {
         if (packet.Message.Topic is null)
         {
+#pragma warning disable IDE0301 // Collection initialization - Array.Empty is required for StyleCop SA1010
             return Array.Empty<EventHandler<OnMessageReceivedEventArgs>>();
+#pragma warning restore IDE0301
         }
+
         List<Subscription> tempList;
         try
         {

--- a/Source/HiveMQtt/Client/HiveMQClientUtil.cs
+++ b/Source/HiveMQtt/Client/HiveMQClientUtil.cs
@@ -31,11 +31,9 @@ public partial class HiveMQClient : IDisposable, IHiveMQClient
     internal bool HasPerSubscriptionMessageHandlers =>
         Volatile.Read(ref this.perSubscriptionMessageHandlersPresent) != 0;
 
-    private void RefreshPerSubscriptionMessageHandlersPresent()
-    {
+    private void RefreshPerSubscriptionMessageHandlersPresent() =>
         this.perSubscriptionMessageHandlersPresent =
             this.Subscriptions.Any(s => s.MessageReceivedHandler is not null) ? 1 : 0;
-    }
 
     /// <summary>
     /// Validates whether a subscription already exists.

--- a/Source/HiveMQtt/Client/internal/MessageReceivedDispatchItem.cs
+++ b/Source/HiveMQtt/Client/internal/MessageReceivedDispatchItem.cs
@@ -13,8 +13,10 @@ internal sealed class MessageReceivedDispatchItem
 
     public OnMessageReceivedEventArgs EventArgs { get; init; } = null!;
 
+#pragma warning disable IDE0301 // Collection initialization - Array.Empty is required for StyleCop SA1010
     public IReadOnlyList<EventHandler<OnMessageReceivedEventArgs>> GlobalHandlers { get; init; } =
         Array.Empty<EventHandler<OnMessageReceivedEventArgs>>();
+#pragma warning restore IDE0301
 
     /// <summary>
     /// Gets an optional resolver for per-subscription handlers, invoked on the dispatch consumer thread.

--- a/Source/HiveMQtt/Client/internal/MessageReceivedDispatcher.cs
+++ b/Source/HiveMQtt/Client/internal/MessageReceivedDispatcher.cs
@@ -1,7 +1,6 @@
 namespace HiveMQtt.Client.Internal;
 
 using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using HiveMQtt.Client.Events;
@@ -121,8 +120,10 @@ internal sealed class MessageReceivedDispatcher : IDisposable
 
     private static void DispatchItem(MessageReceivedDispatchItem item)
     {
+#pragma warning disable IDE0301 // Collection initialization - Array.Empty is required for StyleCop SA1010
         var subscriptionHandlers =
             item.ResolveSubscriptionHandlers?.Invoke() ?? Array.Empty<EventHandler<OnMessageReceivedEventArgs>>();
+#pragma warning restore IDE0301
 
         if (item.GlobalHandlers.Count == 0 && subscriptionHandlers.Count == 0)
         {

--- a/Tests/HiveMQtt.Test/HiveMQClient/MessageOrderingTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/MessageOrderingTest.cs
@@ -5,14 +5,18 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using HiveMQtt.Client;
-using HiveMQtt.Client.Events;
-using HiveMQtt.Client.Options;
 using HiveMQtt.MQTT5.Types;
 using Xunit;
 
 [Collection("Broker")]
 public class MessageOrderingTest
 {
+#pragma warning disable IDE0300 // Collection initialization - array syntax required for StyleCop SA1010
+    private static readonly string[] GlobalBeforePerSubExpected = new[] { "global", "persub" };
+
+    private static readonly int[] AsyncStartOrderExpected = new[] { 0, 1 };
+#pragma warning restore IDE0300
+
     [Fact]
     public async Task QoS1_GlobalHandler_PreservesInvocationOrderAsync()
     {
@@ -182,7 +186,7 @@ public class MessageOrderingTest
         await subscriber.DisconnectAsync().ConfigureAwait(false);
         await publisher.DisconnectAsync().ConfigureAwait(false);
 
-        Assert.Equal(new[] { "global", "persub" }, order);
+        Assert.Equal(GlobalBeforePerSubExpected, order);
     }
 
     [Fact]
@@ -233,17 +237,14 @@ public class MessageOrderingTest
         await subscriber.DisconnectAsync().ConfigureAwait(false);
         await publisher.DisconnectAsync().ConfigureAwait(false);
 
-        Assert.Equal(new[] { 0, 1 }, startOrder);
+        Assert.Equal(AsyncStartOrderExpected, startOrder);
     }
 
     [Fact]
-    public async Task ReentrantPublish_FromHandler_DoesNotDeadlockAsync()
-    {
+    public async Task ReentrantPublish_FromHandler_DoesNotDeadlockAsync() =>
         await RunReentrancyTestAsync(async (subscriber, publisher, testTopic, ackTopic) =>
-        {
-            await publisher.PublishAsync(ackTopic, "done", QualityOfService.AtMostOnceDelivery).ConfigureAwait(false);
-        }).ConfigureAwait(false);
-    }
+            await publisher.PublishAsync(ackTopic, "done", QualityOfService.AtMostOnceDelivery).ConfigureAwait(false))
+            .ConfigureAwait(false);
 
     [Fact]
     public async Task ReentrantSubscribe_FromHandler_DoesNotDeadlockAsync()

--- a/Tests/HiveMQtt.Test/HiveMQClient/OverlappingSubscriptionTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/OverlappingSubscriptionTest.cs
@@ -2,7 +2,6 @@ namespace HiveMQtt.Test.HiveMQClient;
 
 using System.Threading.Tasks;
 using HiveMQtt.Client;
-using HiveMQtt.Client.Events;
 using HiveMQtt.Client.Options;
 using HiveMQtt.MQTT5.ReasonCodes;
 using HiveMQtt.MQTT5.Types;
@@ -17,8 +16,9 @@ public class OverlappingSubscriptionTest
     /// <summary>
     /// Test that FireAllMatchingHandlers (default) fires all matching subscription handlers.
     /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task FireAllMatchingHandlers_Behavior_FiresAllHandlers()
+    public async Task FireAllMatchingHandlers_Behavior_FiresAllHandlersAsync()
     {
         var options = new HiveMQClientOptionsBuilder()
             .WithClientId("FireAllMatchingHandlers_FiresAll")
@@ -49,18 +49,12 @@ public class OverlappingSubscriptionTest
 
         var opts2 = new SubscribeOptions();
         opts2.TopicFilters.Add(new TopicFilter($"{prefix}/room/a/b/#", QualityOfService.AtLeastOnceDelivery));
-        opts2.Handlers[$"{prefix}/room/a/b/#"] = (s, e) =>
-        {
-            Interlocked.Increment(ref handler2Count);
-        };
+        opts2.Handlers[$"{prefix}/room/a/b/#"] = (s, e) => Interlocked.Increment(ref handler2Count);
         await client.SubscribeAsync(opts2).ConfigureAwait(false);
 
         var opts3 = new SubscribeOptions();
         opts3.TopicFilters.Add(new TopicFilter($"{prefix}/room/a/#", QualityOfService.AtLeastOnceDelivery));
-        opts3.Handlers[$"{prefix}/room/a/#"] = (s, e) =>
-        {
-            Interlocked.Increment(ref handler3Count);
-        };
+        opts3.Handlers[$"{prefix}/room/a/#"] = (s, e) => Interlocked.Increment(ref handler3Count);
         await client.SubscribeAsync(opts3).ConfigureAwait(false);
 
         // Publish a message that matches all three subscriptions
@@ -82,8 +76,9 @@ public class OverlappingSubscriptionTest
     /// <summary>
     /// Test that FireFirstMatchingHandler fires only the first matching subscription handler.
     /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task FireFirstMatchingHandler_Behavior_FiresOnlyFirstHandler()
+    public async Task FireFirstMatchingHandler_Behavior_FiresOnlyFirstHandlerAsync()
     {
         var options = new HiveMQClientOptionsBuilder()
             .WithClientId("FireFirstMatchingHandler_FiresFirst")
@@ -114,18 +109,12 @@ public class OverlappingSubscriptionTest
 
         var opts2 = new SubscribeOptions();
         opts2.TopicFilters.Add(new TopicFilter($"{prefix}/room/a/b/#", QualityOfService.AtLeastOnceDelivery));
-        opts2.Handlers[$"{prefix}/room/a/b/#"] = (s, e) =>
-        {
-            Interlocked.Increment(ref handler2Count);
-        };
+        opts2.Handlers[$"{prefix}/room/a/b/#"] = (s, e) => Interlocked.Increment(ref handler2Count);
         await client.SubscribeAsync(opts2).ConfigureAwait(false);
 
         var opts3 = new SubscribeOptions();
         opts3.TopicFilters.Add(new TopicFilter($"{prefix}/room/a/#", QualityOfService.AtLeastOnceDelivery));
-        opts3.Handlers[$"{prefix}/room/a/#"] = (s, e) =>
-        {
-            Interlocked.Increment(ref handler3Count);
-        };
+        opts3.Handlers[$"{prefix}/room/a/#"] = (s, e) => Interlocked.Increment(ref handler3Count);
         await client.SubscribeAsync(opts3).ConfigureAwait(false);
 
         // Publish a message that matches all three subscriptions
@@ -147,8 +136,9 @@ public class OverlappingSubscriptionTest
     /// <summary>
     /// Test that FireFirstMatchingHandler with global handler fires both global and first subscription handler.
     /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task FireFirstMatchingHandler_WithGlobalHandler_BothFire()
+    public async Task FireFirstMatchingHandler_WithGlobalHandler_BothFireAsync()
     {
         var options = new HiveMQClientOptionsBuilder()
             .WithClientId("FireFirst_GlobalAndPerSub")
@@ -169,7 +159,7 @@ public class OverlappingSubscriptionTest
         // Set up global handler
         client.OnMessageReceived += (s, e) =>
         {
-            if (e.PublishMessage.Topic!.StartsWith(prefix))
+            if (e.PublishMessage.Topic!.StartsWith(prefix, StringComparison.Ordinal))
             {
                 Interlocked.Increment(ref globalCount);
             }
@@ -227,8 +217,9 @@ public class OverlappingSubscriptionTest
     /// <summary>
     /// Test edge case: FireFirstMatchingHandler when first subscription has no handler.
     /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous test operation.</returns>
     [Fact]
-    public async Task FireFirstMatchingHandler_FirstSubscriptionNoHandler_DoesNotFire()
+    public async Task FireFirstMatchingHandler_FirstSubscriptionNoHandler_DoesNotFireAsync()
     {
         var options = new HiveMQClientOptionsBuilder()
             .WithClientId("FireFirst_FirstNoHandler")
@@ -249,7 +240,7 @@ public class OverlappingSubscriptionTest
         // Set up global handler
         client.OnMessageReceived += (s, e) =>
         {
-            if (e.PublishMessage.Topic!.StartsWith(prefix))
+            if (e.PublishMessage.Topic!.StartsWith(prefix, StringComparison.Ordinal))
             {
                 Interlocked.Increment(ref globalCount);
                 messageReceived.TrySetResult(true);
@@ -262,10 +253,7 @@ public class OverlappingSubscriptionTest
         // Second subscription WITH a per-subscription handler
         var opts = new SubscribeOptions();
         opts.TopicFilters.Add(new TopicFilter($"{prefix}/room/+", QualityOfService.AtLeastOnceDelivery));
-        opts.Handlers[$"{prefix}/room/+"] = (s, e) =>
-        {
-            Interlocked.Increment(ref perSubCount);
-        };
+        opts.Handlers[$"{prefix}/room/+"] = (s, e) => Interlocked.Increment(ref perSubCount);
         await client.SubscribeAsync(opts).ConfigureAwait(false);
 
         // Publish a message that matches both

--- a/Tests/HiveMQtt.Test/RawClient/RawClientMessageOrderingTest.cs
+++ b/Tests/HiveMQtt.Test/RawClient/RawClientMessageOrderingTest.cs
@@ -3,7 +3,6 @@ namespace HiveMQtt.Test.RawClient;
 using System;
 using System.Threading.Tasks;
 using HiveMQtt.Client;
-using HiveMQtt.Client.Options;
 using HiveMQtt.MQTT5.Types;
 using HiveMQtt.Test.HiveMQClient;
 using Xunit;


### PR DESCRIPTION
## Summary
Cleans up the analyzer warnings that showed up on main after the QoS 1/2 message-dispatch and overlapping-subscription changes. Build is warning-free again.

Touches the client dispatch path, related tests, and a couple of Sparkplug style nits.

## Test plan
- [x] `dotnet build --no-incremental` — 0 warnings