### PR TITLE
Fix: Disconnect when PINGRESP is missing within ResponseTimeoutInMs

### DIFF
--- a/Documentation/docs/hivemqtt/reference/client_options.md
+++ b/Documentation/docs/hivemqtt/reference/client_options.md
@@ -32,7 +32,7 @@ The `HiveMQClientOptions` class provides options for configuring the HiveMQ MQTT
 ----------------
 
 * Type: `int`
-* Description: The maximum time interval that is permitted to elapse between the point at which the Client finishes transmitting one MQTT Control Packet and the point it starts sending the next.
+* Description: The maximum time interval that is permitted to elapse between the point at which the Client finishes transmitting one MQTT Control Packet and the point it starts sending the next. When a PINGREQ is sent and no PINGRESP arrives within `ResponseTimeoutInMs`, the client closes the connection.
 
 ### `CleanStart`
 ----------------
@@ -130,7 +130,7 @@ The `HiveMQClientOptions` class provides options for configuring the HiveMQ MQTT
 -------------------------
 
 * Type: `int`
-* Description: The time in milliseconds to wait for a response from transactional packets.
+* Description: The time in milliseconds to wait for a response from transactional packets (Publish, Subscribe, Unsubscribe, Disconnect). Also used as the maximum time to wait for a PINGRESP after sending a PINGREQ; if no PINGRESP arrives within this timeout, the client closes the connection (MQTT Keep Alive recommendation).
 
 ### `AutomaticReconnect`
 -------------------------

--- a/Documentation/docs/hivemqtt/reference/client_options_builder.md
+++ b/Documentation/docs/hivemqtt/reference/client_options_builder.md
@@ -88,7 +88,7 @@ Sets whether to use a clean start.
 
 Sets the keep alive period.
 
-**Description:** The keep alive period is the time interval between two control packets (PINGREQ and PINGRESP) sent by the client to the broker. This value is used to detect network failures and maintain the connection.
+**Description:** The keep alive period is the maximum time interval in seconds that is permitted to elapse between the point at which the client finishes transmitting one MQTT Control Packet and the point it starts sending the next. When idle, the client sends a PINGREQ; if no PINGRESP arrives within `ResponseTimeoutInMs`, the client closes the connection to detect half-open failures.
 
 **Example:** `WithKeepAlive(60)`
 

--- a/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
@@ -206,12 +206,16 @@ public partial class ConnectionManager : IDisposable
     /// </summary>
     /// <param name="timeoutMs">Maximum time to wait for PINGRESP after PINGREQ was sent.
     /// Aligns with <see cref="Task.WaitAsync(TimeSpan)"/> / <see cref="Timeout"/> semantics:
-    /// <see cref="Timeout.Infinite"/> (-1) and other negative values disable the check;
-    /// 0 means immediate timeout once the PINGREQ has been sent.</param>
+    /// only <see cref="Timeout.Infinite"/> (-1) disables the check;
+    /// 0 means immediate timeout once the PINGREQ has been sent.
+    /// Values less than -1 are invalid for <c>TimeSpan.FromMilliseconds</c>/<c>WaitAsync</c>
+    /// elsewhere and are treated as disabled here so the monitor does not throw.</param>
     /// <returns>True if the ping response has timed out.</returns>
     private bool IsPingRespTimedOut(int timeoutMs)
     {
-        // Negative values (Timeout.Infinite == -1, and < -1) disable the PINGRESP timeout
+        // Only Timeout.Infinite (-1) is the supported "no timeout" value (WaitAsync / TimeSpan).
+        // Values < -1 are invalid for TimeSpan.FromMilliseconds and are treated as disabled
+        // here to avoid crashing the connection monitor.
         if (timeoutMs < 0 || Volatile.Read(ref this.awaitingPingResp) == 0)
         {
             return false;

--- a/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
@@ -44,6 +44,12 @@ public partial class ConnectionManager : IDisposable
     // This is how we kill innocent and not so innocent Tasks
     private CancellationTokenSource cancellationTokenSource;
 
+    // 1 when a PINGREQ has been sent and we are waiting for PINGRESP; 0 otherwise
+    private int awaitingPingResp;
+
+    // Environment.TickCount64 when the outstanding PINGREQ was marked
+    private long pingReqSentTimestamp;
+
     // The state of the connection (thread-safe using Interlocked)
     private int stateValue = (int)ConnectState.Disconnected;
 
@@ -165,6 +171,42 @@ public partial class ConnectionManager : IDisposable
     /// Resets the not-disconnected signal. Called when state transitions to Disconnected.
     /// </summary>
     internal void ResetNotDisconnectedSignal() => this.notDisconnectedSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    /// <summary>
+    /// Marks that a PINGREQ has been sent and we are awaiting a PINGRESP.
+    /// Call before writing so a fast PINGRESP cannot race past the mark.
+    /// </summary>
+    private void MarkPingReqOutstanding()
+    {
+        Interlocked.Exchange(ref this.pingReqSentTimestamp, Environment.TickCount64);
+        Interlocked.Exchange(ref this.awaitingPingResp, 1);
+    }
+
+    /// <summary>
+    /// Clears the outstanding PINGREQ / awaiting-PINGRESP state.
+    /// </summary>
+    private void ClearAwaitingPingResp() => Interlocked.Exchange(ref this.awaitingPingResp, 0);
+
+    /// <summary>
+    /// Returns true when a PINGREQ is outstanding and the response deadline has elapsed.
+    /// </summary>
+    /// <param name="timeoutMs">Maximum time to wait for PINGRESP after PINGREQ was sent.</param>
+    /// <returns>True if the ping response has timed out.</returns>
+    private bool IsPingRespTimedOut(int timeoutMs)
+    {
+        if (Volatile.Read(ref this.awaitingPingResp) == 0)
+        {
+            return false;
+        }
+
+        var elapsedMs = Environment.TickCount64 - Volatile.Read(ref this.pingReqSentTimestamp);
+        return elapsedMs > timeoutMs;
+    }
+
+    /// <summary>
+    /// Returns true when a PINGREQ has been sent and PINGRESP has not yet arrived.
+    /// </summary>
+    private bool IsAwaitingPingResp() => Volatile.Read(ref this.awaitingPingResp) != 0;
 
     internal async Task<bool> ConnectAsync()
     {

--- a/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
@@ -173,10 +173,20 @@ public partial class ConnectionManager : IDisposable
     internal void ResetNotDisconnectedSignal() => this.notDisconnectedSignal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
     /// <summary>
-    /// Marks that a PINGREQ has been sent and we are awaiting a PINGRESP.
-    /// Call before writing so a fast PINGRESP cannot race past the mark.
+    /// Marks that a PINGREQ has been queued but not yet written.
+    /// Prevents pile-up without starting the PINGRESP deadline clock.
     /// </summary>
-    private void MarkPingReqOutstanding()
+    private void MarkPingReqQueued()
+    {
+        Interlocked.Exchange(ref this.pingReqSentTimestamp, 0);
+        Interlocked.Exchange(ref this.awaitingPingResp, 1);
+    }
+
+    /// <summary>
+    /// Marks that a PINGREQ has been (or is about to be) written and starts the PINGRESP deadline.
+    /// Call immediately before the transport write so a fast PINGRESP cannot race past the mark.
+    /// </summary>
+    private void MarkPingReqSent()
     {
         Interlocked.Exchange(ref this.pingReqSentTimestamp, Environment.TickCount64);
         Interlocked.Exchange(ref this.awaitingPingResp, 1);
@@ -185,28 +195,47 @@ public partial class ConnectionManager : IDisposable
     /// <summary>
     /// Clears the outstanding PINGREQ / awaiting-PINGRESP state.
     /// </summary>
-    private void ClearAwaitingPingResp() => Interlocked.Exchange(ref this.awaitingPingResp, 0);
+    private void ClearAwaitingPingResp()
+    {
+        Interlocked.Exchange(ref this.pingReqSentTimestamp, 0);
+        Interlocked.Exchange(ref this.awaitingPingResp, 0);
+    }
 
     /// <summary>
-    /// Returns true when a PINGREQ is outstanding and the response deadline has elapsed.
+    /// Returns true when a PINGREQ has been sent and the response deadline has elapsed.
     /// </summary>
     /// <param name="timeoutMs">Maximum time to wait for PINGRESP after PINGREQ was sent.
-    /// Values less than or equal to zero disable the PINGRESP timeout check.</param>
+    /// Aligns with <see cref="Task.WaitAsync(TimeSpan)"/> / <see cref="Timeout"/> semantics:
+    /// <see cref="Timeout.Infinite"/> (-1) and other negative values disable the check;
+    /// 0 means immediate timeout once the PINGREQ has been sent.</param>
     /// <returns>True if the ping response has timed out.</returns>
     private bool IsPingRespTimedOut(int timeoutMs)
     {
-        // Match WaitAsync semantics where negative timeouts mean infinite / no timeout
-        if (timeoutMs <= 0 || Volatile.Read(ref this.awaitingPingResp) == 0)
+        // Negative values (Timeout.Infinite == -1, and < -1) disable the PINGRESP timeout
+        if (timeoutMs < 0 || Volatile.Read(ref this.awaitingPingResp) == 0)
         {
             return false;
         }
 
-        var elapsedMs = Environment.TickCount64 - Volatile.Read(ref this.pingReqSentTimestamp);
+        // Deadline starts only when the PINGREQ is actually written (timestamp != 0)
+        var sentTimestamp = Volatile.Read(ref this.pingReqSentTimestamp);
+        if (sentTimestamp == 0)
+        {
+            return false;
+        }
+
+        // 0 == immediate timeout once sent (WaitAsync(TimeSpan.Zero) semantics)
+        if (timeoutMs == 0)
+        {
+            return true;
+        }
+
+        var elapsedMs = Environment.TickCount64 - sentTimestamp;
         return elapsedMs > timeoutMs;
     }
 
     /// <summary>
-    /// Returns true when a PINGREQ has been sent and PINGRESP has not yet arrived.
+    /// Returns true when a PINGREQ is queued or sent and PINGRESP has not yet arrived.
     /// </summary>
     private bool IsAwaitingPingResp() => Volatile.Read(ref this.awaitingPingResp) != 0;
 

--- a/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
@@ -190,11 +190,13 @@ public partial class ConnectionManager : IDisposable
     /// <summary>
     /// Returns true when a PINGREQ is outstanding and the response deadline has elapsed.
     /// </summary>
-    /// <param name="timeoutMs">Maximum time to wait for PINGRESP after PINGREQ was sent.</param>
+    /// <param name="timeoutMs">Maximum time to wait for PINGRESP after PINGREQ was sent.
+    /// Values less than or equal to zero disable the PINGRESP timeout check.</param>
     /// <returns>True if the ping response has timed out.</returns>
     private bool IsPingRespTimedOut(int timeoutMs)
     {
-        if (Volatile.Read(ref this.awaitingPingResp) == 0)
+        // Match WaitAsync semantics where negative timeouts mean infinite / no timeout
+        if (timeoutMs <= 0 || Volatile.Read(ref this.awaitingPingResp) == 0)
         {
             return false;
         }

--- a/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManager.cs
@@ -234,8 +234,8 @@ public partial class ConnectionManager : IDisposable
             return true;
         }
 
-        var elapsedMs = Environment.TickCount64 - sentTimestamp;
-        return elapsedMs > timeoutMs;
+var elapsedMs = Environment.TickCount64 - sentTimestamp;
+return elapsedMs >= timeoutMs;
     }
 
     /// <summary>

--- a/Source/HiveMQtt/Client/Connection/ConnectionManagerHandlers.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManagerHandlers.cs
@@ -471,6 +471,9 @@ public partial class ConnectionManager
 
         Logger.Debug($"HandleDisconnection: Handling disconnection. clean={clean}.");
 
+        // Clear any outstanding PINGREQ so the next connect cycle starts clean
+        this.ClearAwaitingPingResp();
+
         // Reset the connection-ready signal for the next connect cycle
         this.ResetConnectedSignal();
 

--- a/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
@@ -110,11 +110,25 @@ public partial class ConnectionManager
                 // If connected and no recent packets have been sent, send a ping
                 if (currentState == ConnectState.Connected)
                 {
-                    if (this.Client.Options.KeepAlive > 0 && this.lastCommunicationTimer.Elapsed > TimeSpan.FromSeconds(keepAlivePeriod))
+                    if (this.Client.Options.KeepAlive > 0)
                     {
-                        // Send PingReq
-                        Logger.Trace($"{this.Client.Options.ClientId}-(CM)- --> PingReq");
-                        this.SendQueue.Enqueue(new PingReqPacket());
+                        // MQTT Keep Alive SHOULD: disconnect if PINGRESP does not arrive in time
+                        if (this.IsPingRespTimedOut(this.Client.Options.ResponseTimeoutInMs))
+                        {
+                            Logger.Warn($"{this.Client.Options.ClientId}-(CM)- PINGRESP not received within {this.Client.Options.ResponseTimeoutInMs}ms. Disconnecting...");
+                            await this.HandleDisconnectionAsync(false).ConfigureAwait(false);
+                            break;
+                        }
+
+                        // Do not enqueue another PINGREQ while one is still awaiting a response
+                        if (!this.IsAwaitingPingResp() &&
+                            this.lastCommunicationTimer.Elapsed > TimeSpan.FromSeconds(keepAlivePeriod))
+                        {
+                            // Mark before enqueue so the next monitor cycle cannot pile up PINGREQs
+                            this.MarkPingReqOutstanding();
+                            Logger.Trace($"{this.Client.Options.ClientId}-(CM)- --> PingReq");
+                            this.SendQueue.Enqueue(new PingReqPacket());
+                        }
                     }
                 }
 
@@ -340,8 +354,19 @@ public partial class ConnectionManager
 
                     case PingReqPacket pingReqPacket:
                         Logger.Trace($"{this.Client.Options.ClientId}-(W)- --> Sending PingReqPacket");
+
+                        // Mark outstanding before write so a fast PINGRESP cannot race past the mark
+                        this.MarkPingReqOutstanding();
                         writeSuccess = await this.Transport.WriteAsync(PingReqPacket.Encode(), cancellationToken).ConfigureAwait(false);
-                        this.Client.OnPingReqSentEventLauncher(pingReqPacket);
+                        if (!writeSuccess)
+                        {
+                            this.ClearAwaitingPingResp();
+                        }
+                        else
+                        {
+                            this.Client.OnPingReqSentEventLauncher(pingReqPacket);
+                        }
+
                         break;
 
                     default:
@@ -609,6 +634,7 @@ public partial class ConnectionManager
 
                     case PingRespPacket pingRespPacket:
                         Logger.Trace($"{this.Client.Options.ClientId}-(RPH)- <-- Received PingResp");
+                        this.ClearAwaitingPingResp();
                         this.Client.OnPingRespReceivedEventLauncher(pingRespPacket);
                         break;
 

--- a/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
@@ -116,7 +116,40 @@ public partial class ConnectionManager
                         if (this.IsPingRespTimedOut(this.Client.Options.ResponseTimeoutInMs))
                         {
                             Logger.Warn($"{this.Client.Options.ClientId}-(CM)- PINGRESP not received within {this.Client.Options.ResponseTimeoutInMs}ms. Disconnecting...");
-                            await this.HandleDisconnectionAsync(false).ConfigureAwait(false);
+
+                            // Fire-and-forget: HandleDisconnectionAsync awaits ConnectionMonitorThread via
+                            // CancelBackgroundTasksAsync, so awaiting it here would self-deadlock (~5s timeout).
+                            _ = Task.Run(async () =>
+                            {
+                                try
+                                {
+                                    if (this.State == ConnectState.Disconnected)
+                                    {
+                                        return;
+                                    }
+
+                                    if (!await this.disconnectionSemaphore.WaitAsync(0).ConfigureAwait(false))
+                                    {
+                                        return;
+                                    }
+
+                                    try
+                                    {
+                                        if (this.State != ConnectState.Disconnected)
+                                        {
+                                            await this.HandleDisconnectionAsync(false).ConfigureAwait(false);
+                                        }
+                                    }
+                                    finally
+                                    {
+                                        this.disconnectionSemaphore.Release();
+                                    }
+                                }
+                                catch (Exception ex)
+                                {
+                                    Logger.Warn($"{this.Client.Options.ClientId}-(CM)- Exception during PINGRESP timeout disconnect: {ex.Message}");
+                                }
+                            });
                             break;
                         }
 

--- a/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
@@ -157,8 +157,8 @@ public partial class ConnectionManager
                         if (!this.IsAwaitingPingResp() &&
                             this.lastCommunicationTimer.Elapsed > TimeSpan.FromSeconds(keepAlivePeriod))
                         {
-                            // Mark before enqueue so the next monitor cycle cannot pile up PINGREQs
-                            this.MarkPingReqOutstanding();
+                            // Mark queued (not sent) so we do not start the deadline until the writer sends
+                            this.MarkPingReqQueued();
                             Logger.Trace($"{this.Client.Options.ClientId}-(CM)- --> PingReq");
                             this.SendQueue.Enqueue(new PingReqPacket());
                         }
@@ -388,8 +388,8 @@ public partial class ConnectionManager
                     case PingReqPacket pingReqPacket:
                         Logger.Trace($"{this.Client.Options.ClientId}-(W)- --> Sending PingReqPacket");
 
-                        // Mark outstanding before write so a fast PINGRESP cannot race past the mark
-                        this.MarkPingReqOutstanding();
+                        // Start the PINGRESP deadline immediately before write (not at enqueue time)
+                        this.MarkPingReqSent();
                         writeSuccess = await this.Transport.WriteAsync(PingReqPacket.Encode(), cancellationToken).ConfigureAwait(false);
                         if (!writeSuccess)
                         {

--- a/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
@@ -147,7 +147,7 @@ public partial class ConnectionManager
                                 }
                                 catch (Exception ex)
                                 {
-                                    Logger.Warn($"{this.Client.Options.ClientId}-(CM)- Exception during PINGRESP timeout disconnect: {ex.Message}");
+                                    Logger.Warn($"{this.Client.Options.ClientId}-(CM)- Exception during PINGRESP timeout disconnect: {ex}");
                                 }
                             });
                             break;

--- a/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
+++ b/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
@@ -217,7 +217,9 @@ public class HiveMQClientOptions
 
     /// <summary>
     /// Gets or sets the time in milliseconds to wait for a response in a transactional operation.
-    /// This could be a Publish, Subscribe, Unsubscribe, or Disconnect operation.
+    /// This could be a Publish, Subscribe, Unsubscribe, Disconnect, or PINGRESP after PINGREQ.
+    /// If PINGRESP is not received within this timeout after a PINGREQ is sent, the client
+    /// closes the network connection (MQTT Keep Alive SHOULD).
     /// </summary>
     public int ResponseTimeoutInMs { get; set; }
 

--- a/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
+++ b/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
@@ -221,6 +221,7 @@ public class HiveMQClientOptions
     /// If PINGRESP is not received within this timeout after a PINGREQ is sent, the client
     /// closes the network connection (MQTT Keep Alive SHOULD).
     /// Use -1 (<c>Timeout.Infinite</c>) to disable the PINGRESP deadline; 0 means immediate timeout.
+    /// Values less than -1 are not valid for <c>WaitAsync</c> elsewhere and should not be used.
     /// </summary>
     public int ResponseTimeoutInMs { get; set; }
 

--- a/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
+++ b/Source/HiveMQtt/Client/Options/HiveMQClientOptions.cs
@@ -220,6 +220,7 @@ public class HiveMQClientOptions
     /// This could be a Publish, Subscribe, Unsubscribe, Disconnect, or PINGRESP after PINGREQ.
     /// If PINGRESP is not received within this timeout after a PINGREQ is sent, the client
     /// closes the network connection (MQTT Keep Alive SHOULD).
+    /// Use -1 (<c>Timeout.Infinite</c>) to disable the PINGRESP deadline; 0 means immediate timeout.
     /// </summary>
     public int ResponseTimeoutInMs { get; set; }
 

--- a/Tests/HiveMQtt.Test/HiveMQClient/Plan/KeepAliveTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/Plan/KeepAliveTest.cs
@@ -174,7 +174,6 @@ public class KeepAliveTest
     {
         private TcpListener? listener;
         private CancellationTokenSource? cts;
-        private Task? acceptLoop;
 
         public int Port { get; private set; }
 
@@ -184,7 +183,7 @@ public class KeepAliveTest
             this.listener.Start();
             this.Port = ((IPEndPoint)this.listener.LocalEndpoint).Port;
             this.cts = new CancellationTokenSource();
-            this.acceptLoop = this.AcceptLoopAsync(this.cts.Token);
+            _ = this.AcceptLoopAsync(this.cts.Token);
             return Task.CompletedTask;
         }
 

--- a/Tests/HiveMQtt.Test/HiveMQClient/Plan/KeepAliveTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/Plan/KeepAliveTest.cs
@@ -198,7 +198,15 @@ public class KeepAliveTest
                     // Parameterless AcceptTcpClientAsync for net6.0 compatibility;
                     // listener.Stop() in Dispose unblocks and exits the loop.
                     tcpClient = await this.listener!.AcceptTcpClientAsync().ConfigureAwait(false);
-                    _ = this.HandleClientAsync(tcpClient, cancellationToken);
+                    _ = this.HandleClientAsync(tcpClient, cancellationToken).ContinueWith(
+                        t =>
+                        {
+                            // Observe faults so they do not become unobserved task exceptions
+                            _ = t.Exception;
+                        },
+                        CancellationToken.None,
+                        TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously,
+                        TaskScheduler.Default);
                 }
                 catch (ObjectDisposedException)
                 {

--- a/Tests/HiveMQtt.Test/HiveMQClient/Plan/KeepAliveTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/Plan/KeepAliveTest.cs
@@ -195,8 +195,23 @@ public class KeepAliveTest
                 TcpClient? tcpClient = null;
                 try
                 {
-                    tcpClient = await this.listener!.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+                    // Parameterless AcceptTcpClientAsync for net6.0 compatibility;
+                    // listener.Stop() in Dispose unblocks and exits the loop.
+                    tcpClient = await this.listener!.AcceptTcpClientAsync().ConfigureAwait(false);
                     _ = this.HandleClientAsync(tcpClient, cancellationToken);
+                }
+                catch (ObjectDisposedException)
+                {
+                    tcpClient?.Dispose();
+                    break;
+                }
+                catch (SocketException)
+                {
+                    tcpClient?.Dispose();
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        break;
+                    }
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -226,7 +241,7 @@ public class KeepAliveTest
 
                 // MQTT 5 CONNACK: Success, no session present, empty properties
                 // Fixed header 0x20, remaining length 3, flags 0, reason 0, property length 0
-                byte[] connAck = [0x20, 0x03, 0x00, 0x00, 0x00];
+                byte[] connAck = new byte[] { 0x20, 0x03, 0x00, 0x00, 0x00 };
                 await stream.WriteAsync(connAck.AsMemory(0, connAck.Length), cancellationToken).ConfigureAwait(false);
                 await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
 

--- a/Tests/HiveMQtt.Test/HiveMQClient/Plan/KeepAliveTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/Plan/KeepAliveTest.cs
@@ -1,5 +1,7 @@
 namespace HiveMQtt.Test.HiveMQClient.Plan;
 
+using System.Net;
+using System.Net.Sockets;
 using System.Threading.Tasks;
 using FluentAssertions;
 using HiveMQtt.Client;
@@ -73,5 +75,186 @@ public class KeepAliveTest
 
         var disconnectResult = await client.DisconnectAsync().ConfigureAwait(false);
         disconnectResult.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task Client_Receives_PingResp_And_Stays_Connected_Async()
+    {
+        var options = new HiveMQClientOptionsBuilder()
+                        .WithKeepAlive(3)
+                        .Build();
+        var client = new HiveMQClient(options);
+
+        var pingReqSent = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pingRespReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnPingSent(object? sender, OnPingReqSentEventArgs e) => pingReqSent.TrySetResult(true);
+        void OnPingResp(object? sender, OnPingRespReceivedEventArgs e) => pingRespReceived.TrySetResult(true);
+
+        client.OnPingReqSent += OnPingSent;
+        client.OnPingRespReceived += OnPingResp;
+
+        try
+        {
+            var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+            connectResult.Should().NotBeNull();
+
+            await pingReqSent.Task.WaitAsync(TimeSpan.FromSeconds(6)).ConfigureAwait(false);
+            await pingRespReceived.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+            client.IsConnected().Should().BeTrue();
+        }
+        finally
+        {
+            client.OnPingReqSent -= OnPingSent;
+            client.OnPingRespReceived -= OnPingResp;
+            if (client.IsConnected())
+            {
+                await client.DisconnectAsync().ConfigureAwait(false);
+            }
+
+            client.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task Missing_PingResp_Triggers_Unclean_Disconnect_Async()
+    {
+        // Silent broker: accepts CONNECT, sends CONNACK, never answers PINGREQ.
+        // This simulates a half-open / unresponsive peer for keep-alive timeout detection.
+        using var silentBroker = new SilentMqttBroker();
+        await silentBroker.StartAsync().ConfigureAwait(false);
+
+        var options = new HiveMQClientOptionsBuilder()
+                        .WithBroker("127.0.0.1")
+                        .WithPort(silentBroker.Port)
+                        .WithKeepAlive(2)
+                        .Build();
+        options.ResponseTimeoutInMs = 2000;
+        options.ConnectTimeoutInMs = 5000;
+
+        var client = new HiveMQClient(options);
+        var afterDisconnect = new TaskCompletionSource<AfterDisconnectEventArgs>(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pingReqSent = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void OnAfterDisconnect(object? sender, AfterDisconnectEventArgs e) => afterDisconnect.TrySetResult(e);
+        void OnPingSent(object? sender, OnPingReqSentEventArgs e) => pingReqSent.TrySetResult(true);
+
+        client.AfterDisconnect += OnAfterDisconnect;
+        client.OnPingReqSent += OnPingSent;
+
+        try
+        {
+            var connectResult = await client.ConnectAsync().ConfigureAwait(false);
+            connectResult.Should().NotBeNull();
+            client.IsConnected().Should().BeTrue();
+
+            // Wait for PINGREQ to be sent
+            await pingReqSent.Task.WaitAsync(TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+
+            // Detection ≈ KeepAlive + ResponseTimeoutInMs + monitor poll (2s) + AfterDisconnect delay (1s)
+            var disconnectArgs = await afterDisconnect.Task.WaitAsync(TimeSpan.FromSeconds(15)).ConfigureAwait(false);
+
+            disconnectArgs.CleanDisconnect.Should().BeFalse(
+                "missing PINGRESP should trigger an unclean disconnect");
+            client.IsConnected().Should().BeFalse();
+        }
+        finally
+        {
+            client.AfterDisconnect -= OnAfterDisconnect;
+            client.OnPingReqSent -= OnPingSent;
+            client.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Minimal MQTT 5 broker that accepts a connection and CONNACK, then never sends PINGRESP.
+    /// </summary>
+    private sealed class SilentMqttBroker : IDisposable
+    {
+        private TcpListener? listener;
+        private CancellationTokenSource? cts;
+        private Task? acceptLoop;
+
+        public int Port { get; private set; }
+
+        public Task StartAsync()
+        {
+            this.listener = new TcpListener(IPAddress.Loopback, 0);
+            this.listener.Start();
+            this.Port = ((IPEndPoint)this.listener.LocalEndpoint).Port;
+            this.cts = new CancellationTokenSource();
+            this.acceptLoop = this.AcceptLoopAsync(this.cts.Token);
+            return Task.CompletedTask;
+        }
+
+        private async Task AcceptLoopAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                TcpClient? tcpClient = null;
+                try
+                {
+                    tcpClient = await this.listener!.AcceptTcpClientAsync(cancellationToken).ConfigureAwait(false);
+                    _ = this.HandleClientAsync(tcpClient, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    tcpClient?.Dispose();
+                    break;
+                }
+                catch
+                {
+                    tcpClient?.Dispose();
+                }
+            }
+        }
+
+        private async Task HandleClientAsync(TcpClient tcpClient, CancellationToken cancellationToken)
+        {
+            using (tcpClient)
+            {
+                var stream = tcpClient.GetStream();
+                var buffer = new byte[4096];
+
+                // Read CONNECT (or enough of it)
+                var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+                if (read <= 0)
+                {
+                    return;
+                }
+
+                // MQTT 5 CONNACK: Success, no session present, empty properties
+                // Fixed header 0x20, remaining length 3, flags 0, reason 0, property length 0
+                byte[] connAck = [0x20, 0x03, 0x00, 0x00, 0x00];
+                await stream.WriteAsync(connAck.AsMemory(0, connAck.Length), cancellationToken).ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+
+                // Drain inbound packets (PINGREQ etc.) but never respond — simulates half-open / silent peer
+                while (!cancellationToken.IsCancellationRequested && tcpClient.Connected)
+                {
+                    read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken).ConfigureAwait(false);
+                    if (read <= 0)
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            try
+            {
+                this.cts?.Cancel();
+            }
+            catch
+            {
+                // ignore
+            }
+
+            this.listener?.Stop();
+            this.cts?.Dispose();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Enforce a PINGRESP deadline (`ResponseTimeoutInMs`) after each PINGREQ so half-open connections disconnect uncleanly and can auto-reconnect
- Skip enqueueing additional PINGREQs while one is outstanding; clear outstanding state on PINGRESP and disconnect
- Document keep-alive / response-timeout behavior and add happy-path + silent-broker keep-alive tests

Fixes #357

## Test plan
- [x] `KeepAliveTest` (4 tests) against live broker + silent broker mock
- [ ] Confirm half-open / cable-unplug case fires unclean `AfterDisconnect` within ~`KeepAlive + ResponseTimeoutInMs`
- [ ] Confirm normal keep-alive still receives `OnPingRespReceived` and stays connected