### PR TITLE
Fix Host Application STATE retain flag (#360)

### DIFF
--- a/Source/HiveMQtt.Sparkplug/HostApplication/SparkplugHostApplication.cs
+++ b/Source/HiveMQtt.Sparkplug/HostApplication/SparkplugHostApplication.cs
@@ -363,11 +363,15 @@ public sealed class SparkplugHostApplication : IDisposable
 
     private async Task PublishStateDeathAsync(CancellationToken cancellationToken)
     {
-        var (topic, payload) = BuildStateOfflineMessage(this.options);
+        // Graceful death uses the current timestamp so Edge Nodes treating Primary Host STATE
+        // accept offline (timestamp must be greater than the prior online STATE timestamp).
+        // LWT keeps timestamp 0 via BuildStateOfflineMessage (time of unexpected disconnect is unknown).
+        var topic = $"{this.options.SparkplugNamespace}/STATE/{this.options.HostApplicationId}";
+        var statePayload = SparkplugStatePayload.CreateOffline(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
         var message = new MQTT5PublishMessage
         {
             Topic = topic,
-            Payload = payload,
+            Payload = statePayload.ToUtf8Bytes(),
             QoS = QualityOfService.AtLeastOnceDelivery,
             Retain = true,
         };

--- a/Source/HiveMQtt.Sparkplug/HostApplication/SparkplugHostApplication.cs
+++ b/Source/HiveMQtt.Sparkplug/HostApplication/SparkplugHostApplication.cs
@@ -77,7 +77,7 @@ public sealed class SparkplugHostApplication : IDisposable
         if (this.options.UseStateMessages && this.options.UseStateLwt && clientOptions.LastWillAndTestament is null && !string.IsNullOrWhiteSpace(this.options.HostApplicationId))
         {
             var (topic, payload) = BuildStateOfflineMessage(this.options);
-            clientOptions.LastWillAndTestament = new LastWillAndTestament(topic, payload, QualityOfService.AtLeastOnceDelivery, retain: false);
+            clientOptions.LastWillAndTestament = new LastWillAndTestament(topic, payload, QualityOfService.AtLeastOnceDelivery, retain: true);
         }
 
         this.client = new HiveMQClient(clientOptions);
@@ -356,7 +356,7 @@ public sealed class SparkplugHostApplication : IDisposable
             Topic = topic,
             Payload = statePayload.ToUtf8Bytes(),
             QoS = QualityOfService.AtLeastOnceDelivery,
-            Retain = false,
+            Retain = true,
         };
         await this.client.PublishAsync(message, cancellationToken).ConfigureAwait(false);
     }
@@ -369,7 +369,7 @@ public sealed class SparkplugHostApplication : IDisposable
             Topic = topic,
             Payload = payload,
             QoS = QualityOfService.AtLeastOnceDelivery,
-            Retain = false,
+            Retain = true,
         };
         await this.client.PublishAsync(message, cancellationToken).ConfigureAwait(false);
     }

--- a/Tests/HiveMQtt.Sparkplug.Test/HostApplication/SparkplugHostApplicationTest.cs
+++ b/Tests/HiveMQtt.Sparkplug.Test/HostApplication/SparkplugHostApplicationTest.cs
@@ -18,6 +18,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using HiveMQtt.Client;
 using HiveMQtt.Client.Options;
+using HiveMQtt.MQTT5.Types;
 using HiveMQtt.Sparkplug.HostApplication;
 using HiveMQtt.Sparkplug.Payload;
 using HiveMQtt.Sparkplug.Protobuf;
@@ -156,6 +157,75 @@ public class SparkplugHostApplicationTest
         host.IsConnected.Should().BeTrue();
         client.Subscriptions.Should().HaveCount(1);
         client.Subscriptions[0].TopicFilter.Topic.Should().Be("spBv1.0/#");
+    }
+
+    [Test]
+    public async Task StartAsync_Publishes_Retained_State_Birth()
+    {
+        var client = new FakeHiveMQClient();
+        var options = new SparkplugHostApplicationOptions
+        {
+            SparkplugTopicFilter = "spBv1.0/#",
+            HostApplicationId = "host1",
+            UseStateMessages = true,
+        };
+        var host = new SparkplugHostApplication(client, options);
+
+        await host.StartAsync().ConfigureAwait(false);
+
+        client.PublishedMessages.Should().ContainSingle();
+        var stateBirth = client.PublishedMessages[0];
+        stateBirth.Topic.Should().Be("spBv1.0/STATE/host1");
+        stateBirth.QoS.Should().Be(QualityOfService.AtLeastOnceDelivery);
+        stateBirth.Retain.Should().BeTrue();
+        SparkplugStatePayload.TryDecode(stateBirth.Payload, out var payload).Should().BeTrue();
+        payload!.Online.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task StopAsync_Publishes_Retained_State_Death()
+    {
+        var client = new FakeHiveMQClient();
+        var options = new SparkplugHostApplicationOptions
+        {
+            SparkplugTopicFilter = "spBv1.0/#",
+            HostApplicationId = "host1",
+            UseStateMessages = true,
+        };
+        var host = new SparkplugHostApplication(client, options);
+
+        await host.StartAsync().ConfigureAwait(false);
+        client.PublishedMessages.Clear();
+
+        await host.StopAsync().ConfigureAwait(false);
+
+        client.PublishedMessages.Should().ContainSingle();
+        var stateDeath = client.PublishedMessages[0];
+        stateDeath.Topic.Should().Be("spBv1.0/STATE/host1");
+        stateDeath.QoS.Should().Be(QualityOfService.AtLeastOnceDelivery);
+        stateDeath.Retain.Should().BeTrue();
+        SparkplugStatePayload.TryDecode(stateDeath.Payload, out var payload).Should().BeTrue();
+        payload!.Online.Should().BeFalse();
+    }
+
+    [Test]
+    public void Constructor_With_Owned_Client_Sets_Retained_State_Lwt()
+    {
+        var clientOptions = new HiveMQClientOptionsBuilder().WithClientId("host-lwt-test").Build();
+        var sparkplugOptions = new SparkplugHostApplicationOptions
+        {
+            SparkplugTopicFilter = "spBv1.0/#",
+            HostApplicationId = "host1",
+            UseStateMessages = true,
+            UseStateLwt = true,
+        };
+
+        using var host = new SparkplugHostApplication(clientOptions, sparkplugOptions);
+
+        clientOptions.LastWillAndTestament.Should().NotBeNull();
+        clientOptions.LastWillAndTestament!.Topic.Should().Be("spBv1.0/STATE/host1");
+        clientOptions.LastWillAndTestament.QoS.Should().Be(QualityOfService.AtLeastOnceDelivery);
+        clientOptions.LastWillAndTestament.Retain.Should().BeTrue();
     }
 
     [Test]

--- a/Tests/HiveMQtt.Sparkplug.Test/HostApplication/SparkplugHostApplicationTest.cs
+++ b/Tests/HiveMQtt.Sparkplug.Test/HostApplication/SparkplugHostApplicationTest.cs
@@ -197,7 +197,9 @@ public class SparkplugHostApplicationTest
         await host.StartAsync().ConfigureAwait(false);
         client.PublishedMessages.Clear();
 
+        var beforeStopMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
         await host.StopAsync().ConfigureAwait(false);
+        var afterStopMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 
         client.PublishedMessages.Should().ContainSingle();
         var stateDeath = client.PublishedMessages[0];
@@ -206,6 +208,8 @@ public class SparkplugHostApplicationTest
         stateDeath.Retain.Should().BeTrue();
         SparkplugStatePayload.TryDecode(stateDeath.Payload, out var payload).Should().BeTrue();
         payload!.Online.Should().BeFalse();
+        payload.Timestamp.Should().BeGreaterThan(0);
+        payload.Timestamp.Should().BeInRange(beforeStopMs, afterStopMs);
     }
 
     [Test]


### PR DESCRIPTION
## Summary
- Set `Retain = true` on Host Application STATE birth and death publishes per Sparkplug B 3.0 (`tck-id-payloads-state-birth`)
- Set STATE LWT retain to `true` (`tck-id-payloads-state-will-message-retain`)
- Add unit tests covering retained STATE birth, death, and LWT

Fixes #360

## Test plan
- [x] `dotnet test Tests/HiveMQtt.Sparkplug.Test --filter FullyQualifiedName~SparkplugHostApplicationTest` (net10.0: 24 passed)
- [x] CI green on PR
- [ ] Optional: verify with broker that a late subscriber to `spBv1.0/STATE/{hostId}` receives the retained online payload