### PR TITLE
Add Edge Node Primary Host STATE support (#362)

### DIFF
--- a/Documentation/docs/sparkplug/edge-node.md
+++ b/Documentation/docs/sparkplug/edge-node.md
@@ -12,6 +12,7 @@ Use `SparkplugEdgeNode` to publish Sparkplug node/device lifecycle data and proc
 - Subscribe to NCMD/DCMD commands from Host Applications.
 - Maintain proper birth/death lifecycle sequencing (`bdSeq`).
 - Optionally configure NDEATH LWT for ungraceful disconnect awareness.
+- Optionally follow a Primary Host Application STATE (wait for online, terminate on offline).
 
 ## Typical Setup
 
@@ -42,6 +43,36 @@ var metrics = new[]
 
 await edgeNode.PublishNodeDataAsync(metrics);
 ```
+
+## Primary Host Application
+
+When `PrimaryHostApplicationId` is set, the Edge Node uses single-broker Primary Host Application behavior:
+
+- Subscribes to the exact topic `spBv1.0/STATE/{PrimaryHostApplicationId}` (not `STATE/#`).
+- Waits for an online STATE (including a retained one) before publishing NBIRTH.
+- Raises `StateMessageReceived` for STATE updates.
+- Exposes `IsPrimaryHostOnline`.
+- On a valid offline STATE (`online=false` and timestamp ≥ last online timestamp), publishes NDEATH and disconnects. Call `StartAsync` again after the Host returns online.
+
+When `PrimaryHostApplicationId` is unset, behavior is unchanged (no STATE subscription).
+
+```csharp
+var sparkplugOptions = new SparkplugEdgeNodeOptions
+{
+    GroupId = "myGroup",
+    EdgeNodeId = "myNode",
+    PrimaryHostApplicationId = "myPrimaryHost",
+};
+
+var edgeNode = new SparkplugEdgeNode(clientOptions, sparkplugOptions);
+edgeNode.StateMessageReceived += (_, e) =>
+{
+    Console.WriteLine($"Primary Host online={e.StatePayload!.Online}");
+};
+await edgeNode.StartAsync();
+```
+
+Multi-MQTT-server cycling when the Primary Host goes offline is not implemented yet.
 
 ## Rebirth Handling
 

--- a/Documentation/docs/sparkplug/edge-node.md
+++ b/Documentation/docs/sparkplug/edge-node.md
@@ -49,7 +49,7 @@ await edgeNode.PublishNodeDataAsync(metrics);
 When `PrimaryHostApplicationId` is set, the Edge Node uses single-broker Primary Host Application behavior:
 
 - Subscribes to the exact topic `spBv1.0/STATE/{PrimaryHostApplicationId}` (not `STATE/#`).
-- Waits for an online STATE (including a retained one) before publishing NBIRTH.
+- Waits for an online STATE (including a retained one) before publishing NBIRTH. This wait can block indefinitely; pass a `CancellationToken` (or timeout) to `StartAsync`.
 - Raises `StateMessageReceived` for STATE updates.
 - Exposes `IsPrimaryHostOnline`.
 - On a valid offline STATE (`online=false` and timestamp ≥ last online timestamp), publishes NDEATH and disconnects. Call `StartAsync` again after the Host returns online.

--- a/Source/HiveMQtt.Sparkplug/EdgeNode/SparkplugEdgeNode.cs
+++ b/Source/HiveMQtt.Sparkplug/EdgeNode/SparkplugEdgeNode.cs
@@ -46,6 +46,10 @@ public sealed class SparkplugEdgeNode : IDisposable
     private ulong? currentSessionBdSeq;
     private bool started;
     private bool disposed;
+    private TaskCompletionSource<bool>? primaryHostOnlineWait;
+    private long? lastPrimaryHostOnlineTimestamp;
+    private bool isPrimaryHostOnline;
+    private int primaryHostOfflineShutdownQueued;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SparkplugEdgeNode"/> class using an existing MQTT client.
@@ -96,7 +100,13 @@ public sealed class SparkplugEdgeNode : IDisposable
     public event EventHandler<SparkplugMessageReceivedEventArgs>? DeviceCommandReceived;
 
     /// <summary>
-    /// Event raised when a command message is received but could not be parsed.
+    /// Event raised when a Primary Host Application STATE message is received for the configured
+    /// <see cref="SparkplugEdgeNodeOptions.PrimaryHostApplicationId"/>.
+    /// </summary>
+    public event EventHandler<SparkplugMessageReceivedEventArgs>? StateMessageReceived;
+
+    /// <summary>
+    /// Event raised when a command or STATE message is received but could not be parsed.
     /// </summary>
     public event EventHandler<SparkplugMessageParseErrorEventArgs>? MessageParseError;
 
@@ -126,7 +136,19 @@ public sealed class SparkplugEdgeNode : IDisposable
     public ulong? CurrentSessionBdSeq => this.currentSessionBdSeq;
 
     /// <summary>
+    /// Gets a value indicating whether the configured Primary Host Application is currently considered online.
+    /// Always false when <see cref="SparkplugEdgeNodeOptions.PrimaryHostApplicationId"/> is not set.
+    /// </summary>
+    public bool IsPrimaryHostOnline => this.isPrimaryHostOnline;
+
+    private bool UsesPrimaryHost => !string.IsNullOrWhiteSpace(this.options.PrimaryHostApplicationId);
+
+    /// <summary>
     /// Connects the client, subscribes to NCMD and DCMD topics for this node, and publishes Node Birth (NBIRTH).
+    /// When <see cref="SparkplugEdgeNodeOptions.PrimaryHostApplicationId"/> is set, also subscribes to that Host's STATE
+    /// topic and waits for an online STATE (including a retained one) before publishing NBIRTH. If the Primary Host later
+    /// goes offline with a valid timestamp, the Edge Node publishes NDEATH and disconnects; call <see cref="StartAsync"/>
+    /// again after reconnect to resume (single-broker Primary Host support).
     /// After a reconnect (e.g. following connection loss and automatic or manual reconnection), call <see cref="StartAsync"/> again
     /// to publish a new NBIRTH (re-birth) and resume command subscriptions; the underlying client must be connected before calling.
     /// </summary>
@@ -150,6 +172,7 @@ public sealed class SparkplugEdgeNode : IDisposable
 
             var sessionBdSeq = this.bdSeq;
             this.bdSeq++;
+            Interlocked.Exchange(ref this.primaryHostOfflineShutdownQueued, 0);
 
             if (this.ownsClient && this.options.UseDeathLwt && this.client.Options is { } opts && opts.LastWillAndTestament is null && !string.IsNullOrWhiteSpace(this.options.GroupId) && !string.IsNullOrWhiteSpace(this.options.EdgeNodeId))
             {
@@ -176,6 +199,17 @@ public sealed class SparkplugEdgeNode : IDisposable
             var subOptions = new SubscribeOptions();
             subOptions.TopicFilters.Add(new TopicFilter(ncmdTopic.Build(), QualityOfService.AtLeastOnceDelivery));
             subOptions.TopicFilters.Add(new TopicFilter(dcmdFilter, QualityOfService.AtLeastOnceDelivery));
+
+            TaskCompletionSource<bool>? onlineWait = null;
+            if (this.UsesPrimaryHost)
+            {
+                var stateTopic = $"{this.options.SparkplugNamespace}/STATE/{this.options.PrimaryHostApplicationId}";
+                subOptions.TopicFilters.Add(new TopicFilter(stateTopic, QualityOfService.AtLeastOnceDelivery));
+                onlineWait = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                this.primaryHostOnlineWait = onlineWait;
+                this.isPrimaryHostOnline = false;
+            }
+
             var subscribeResult = await this.client.SubscribeAsync(subOptions).ConfigureAwait(false);
 
             if (subscribeResult.Subscriptions.Count != subOptions.TopicFilters.Count)
@@ -190,6 +224,21 @@ public sealed class SparkplugEdgeNode : IDisposable
                 if (!granted)
                 {
                     throw new InvalidOperationException($"Subscribe failed for topic filter index {i}: {reasonCode}.");
+                }
+            }
+
+            if (onlineWait is not null)
+            {
+                try
+                {
+                    await onlineWait.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    if (ReferenceEquals(this.primaryHostOnlineWait, onlineWait))
+                    {
+                        this.primaryHostOnlineWait = null;
+                    }
                 }
             }
 
@@ -229,6 +278,8 @@ public sealed class SparkplugEdgeNode : IDisposable
         {
             // If startup fails after wiring, always unwind the handler to avoid duplicate command processing on retry.
             this.client.OnMessageReceived -= this.OnClientMessageReceived;
+            this.primaryHostOnlineWait = null;
+            this.isPrimaryHostOnline = false;
 
             // If this instance created the connection for this startup attempt, best-effort disconnect on failure.
             if (connectedByThisStart && this.ownsClient && this.client.IsConnected())
@@ -524,6 +575,12 @@ public sealed class SparkplugEdgeNode : IDisposable
             return;
         }
 
+        if (sparkplugTopic.MessageType == SparkplugMessageType.STATE)
+        {
+            this.HandleState(topicStr, e.PublishMessage.Payload, sparkplugTopic);
+            return;
+        }
+
         if (sparkplugTopic.GroupId != this.options.GroupId || sparkplugTopic.EdgeNodeId != this.options.EdgeNodeId)
         {
             return;
@@ -563,6 +620,136 @@ public sealed class SparkplugEdgeNode : IDisposable
         else
         {
             this.DeviceCommandReceived?.Invoke(this, args);
+        }
+    }
+
+    private void HandleState(string rawTopic, byte[]? payloadBytes, SparkplugTopic topic)
+    {
+        if (!this.UsesPrimaryHost)
+        {
+            return;
+        }
+
+        if (!string.Equals(topic.PrimaryHostId, this.options.PrimaryHostApplicationId, StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (payloadBytes is null || payloadBytes.Length == 0)
+        {
+            this.MessageParseError?.Invoke(this, new SparkplugMessageParseErrorEventArgs(rawTopic, null, "Empty STATE payload."));
+            return;
+        }
+
+        if (!SparkplugStatePayload.TryDecode(payloadBytes, out var statePayload) || statePayload is null)
+        {
+            this.MessageParseError?.Invoke(
+                this,
+                new SparkplugMessageParseErrorEventArgs(
+                    rawTopic,
+                    payloadBytes,
+                    "STATE payload is not valid Sparkplug 3.0 JSON (expected { \"online\": true|false, \"timestamp\": <ms> })."));
+            return;
+        }
+
+        var args = new SparkplugMessageReceivedEventArgs(topic, rawTopic, statePayload);
+        this.StateMessageReceived?.Invoke(this, args);
+
+        if (statePayload.Online)
+        {
+            this.lastPrimaryHostOnlineTimestamp = statePayload.Timestamp;
+            this.isPrimaryHostOnline = true;
+            this.primaryHostOnlineWait?.TrySetResult(true);
+            return;
+        }
+
+        // Offline: only act when timestamp is greater than or equal to the last online STATE timestamp.
+        if (!this.lastPrimaryHostOnlineTimestamp.HasValue || statePayload.Timestamp < this.lastPrimaryHostOnlineTimestamp.Value)
+        {
+            return;
+        }
+
+        this.isPrimaryHostOnline = false;
+
+        if (!this.started)
+        {
+            return;
+        }
+
+        if (Interlocked.CompareExchange(ref this.primaryHostOfflineShutdownQueued, 1, 0) != 0)
+        {
+            return;
+        }
+
+        // Do not block the MQTT receive path on start/stop lock or network I/O.
+        _ = this.TerminateForPrimaryHostOfflineAsync();
+    }
+
+    private async Task TerminateForPrimaryHostOfflineAsync()
+    {
+        try
+        {
+            await this.startStopLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (!this.started)
+                {
+                    return;
+                }
+
+                this.client.OnMessageReceived -= this.OnClientMessageReceived;
+
+                try
+                {
+                    await this.publishSequenceLock.WaitAsync().ConfigureAwait(false);
+                    try
+                    {
+                        var deathPayload = SparkplugPayloadEncoder.CreatePayload(SparkplugPayloadEncoder.GetCurrentTimestamp(), this.sequenceNumber);
+                        if (this.currentSessionBdSeq.HasValue)
+                        {
+                            deathPayload.Metrics.Insert(0, SparkplugPayloadEncoder.CreateBdSeqMetric(this.currentSessionBdSeq.Value));
+                        }
+
+                        await this.PublishPayloadAsync(
+                            SparkplugTopic.NodeDeath(this.options.GroupId!, this.options.EdgeNodeId!, this.options.SparkplugNamespace),
+                            deathPayload,
+                            CancellationToken.None).ConfigureAwait(false);
+                        this.sequenceNumber = SparkplugPayloadEncoder.NextSequenceNumber(this.sequenceNumber);
+                        this.currentSessionBdSeq = null;
+                    }
+                    finally
+                    {
+                        this.publishSequenceLock.Release();
+                    }
+                }
+                catch
+                {
+                    // Best-effort NDEATH; still disconnect and clear started.
+                }
+
+                try
+                {
+                    if (this.client.IsConnected())
+                    {
+                        await this.client.DisconnectAsync().ConfigureAwait(false);
+                    }
+                }
+                catch
+                {
+                    // Best-effort disconnect.
+                }
+
+                this.started = false;
+                this.isPrimaryHostOnline = false;
+            }
+            finally
+            {
+                this.startStopLock.Release();
+            }
+        }
+        finally
+        {
+            Interlocked.Exchange(ref this.primaryHostOfflineShutdownQueued, 0);
         }
     }
 

--- a/Source/HiveMQtt.Sparkplug/EdgeNode/SparkplugEdgeNode.cs
+++ b/Source/HiveMQtt.Sparkplug/EdgeNode/SparkplugEdgeNode.cs
@@ -245,6 +245,11 @@ public sealed class SparkplugEdgeNode : IDisposable
             await this.publishSequenceLock.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
+                if (this.UsesPrimaryHost && !this.isPrimaryHostOnline)
+                {
+                    throw new InvalidOperationException("Primary Host went offline before NBIRTH could be published.");
+                }
+
                 this.sequenceNumber = 0;
                 var birthPayload = SparkplugPayloadEncoder.CreatePayload(SparkplugPayloadEncoder.GetCurrentTimestamp(), 0);
                 birthPayload.Metrics.Insert(0, SparkplugPayloadEncoder.CreateBdSeqMetric(sessionBdSeq));
@@ -266,6 +271,20 @@ public sealed class SparkplugEdgeNode : IDisposable
                 await this.PublishPayloadAsync(SparkplugTopic.NodeBirth(this.options.GroupId!, this.options.EdgeNodeId!, this.options.SparkplugNamespace), birthPayload, cancellationToken).ConfigureAwait(false);
                 this.sequenceNumber = SparkplugPayloadEncoder.NextSequenceNumber(this.sequenceNumber);
                 this.currentSessionBdSeq = sessionBdSeq;
+
+                // Host may have gone offline during NBIRTH publish; do not leave started=true with host offline.
+                if (this.UsesPrimaryHost && !this.isPrimaryHostOnline)
+                {
+                    var deathPayload = SparkplugPayloadEncoder.CreatePayload(SparkplugPayloadEncoder.GetCurrentTimestamp(), this.sequenceNumber);
+                    deathPayload.Metrics.Insert(0, SparkplugPayloadEncoder.CreateBdSeqMetric(sessionBdSeq));
+                    await this.PublishPayloadAsync(
+                        SparkplugTopic.NodeDeath(this.options.GroupId!, this.options.EdgeNodeId!, this.options.SparkplugNamespace),
+                        deathPayload,
+                        cancellationToken).ConfigureAwait(false);
+                    this.sequenceNumber = SparkplugPayloadEncoder.NextSequenceNumber(this.sequenceNumber);
+                    this.currentSessionBdSeq = null;
+                    throw new InvalidOperationException("Primary Host went offline after NBIRTH was published; session aborted with NDEATH.");
+                }
 
                 this.started = true;
             }
@@ -657,7 +676,12 @@ public sealed class SparkplugEdgeNode : IDisposable
 
         if (statePayload.Online)
         {
-            this.lastPrimaryHostOnlineTimestamp = statePayload.Timestamp;
+            // Only advance the watermark; regressive online timestamps must not weaken stale-offline protection.
+            if (!this.lastPrimaryHostOnlineTimestamp.HasValue || statePayload.Timestamp >= this.lastPrimaryHostOnlineTimestamp.Value)
+            {
+                this.lastPrimaryHostOnlineTimestamp = statePayload.Timestamp;
+            }
+
             this.isPrimaryHostOnline = true;
             this.primaryHostOnlineWait?.TrySetResult(true);
             return;
@@ -673,6 +697,9 @@ public sealed class SparkplugEdgeNode : IDisposable
 
         if (!this.started)
         {
+            // Fail a still-pending online wait so StartAsync does not proceed to NBIRTH.
+            this.primaryHostOnlineWait?.TrySetException(
+                new InvalidOperationException("Primary Host went offline before Edge Node start completed."));
             return;
         }
 

--- a/Source/HiveMQtt.Sparkplug/EdgeNode/SparkplugEdgeNodeOptions.cs
+++ b/Source/HiveMQtt.Sparkplug/EdgeNode/SparkplugEdgeNodeOptions.cs
@@ -58,6 +58,14 @@ public class SparkplugEdgeNodeOptions
     public bool UseDeathLwt { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets the Primary Host Application ID. When set, the Edge Node subscribes to
+    /// <c>{SparkplugNamespace}/STATE/{PrimaryHostApplicationId}</c>, waits for an online STATE before publishing
+    /// NBIRTH, raises STATE events, and on a valid offline STATE publishes NDEATH and disconnects (single-broker
+    /// Primary Host Application behavior). When null or empty, Primary Host awareness is disabled.
+    /// </summary>
+    public string? PrimaryHostApplicationId { get; set; }
+
+    /// <summary>
     /// Validates the options and throws if invalid.
     /// </summary>
     /// <exception cref="InvalidOperationException">Thrown when required options are missing or invalid.</exception>
@@ -82,6 +90,11 @@ public class SparkplugEdgeNodeOptions
         {
             SparkplugIdValidator.ValidateGroupId(this.GroupId, nameof(this.GroupId), strict: true);
             SparkplugIdValidator.ValidateEdgeNodeId(this.EdgeNodeId, nameof(this.EdgeNodeId), strict: true);
+
+            if (!string.IsNullOrWhiteSpace(this.PrimaryHostApplicationId))
+            {
+                SparkplugIdValidator.ValidateHostApplicationId(this.PrimaryHostApplicationId, nameof(this.PrimaryHostApplicationId), strict: true);
+            }
         }
     }
 }

--- a/Source/HiveMQtt.Sparkplug/README.md
+++ b/Source/HiveMQtt.Sparkplug/README.md
@@ -28,7 +28,7 @@ Sparkplug B 3.0 extension for the [HiveMQ MQTT Client for .NET](https://github.c
 
 ### 🚀 Features
 - **Host Application**: Subscribe to Sparkplug topics (`spBv1.0/#` or scoped), track Edge Node and Device online/offline state, publish NCMD/DCMD, and optionally use STATE messages and LWT.
-- **Edge Node**: Publish NBIRTH/NDATA/NDEATH and DBIRTH/DDATA/DDEATH, subscribe to NCMD/DCMD, and manage birth/death lifecycle with `bdSeq`.
+- **Edge Node**: Publish NBIRTH/NDATA/NDEATH and DBIRTH/DDATA/DDEATH, subscribe to NCMD/DCMD, manage birth/death lifecycle with `bdSeq`, and optionally follow a Primary Host Application STATE (wait for online before NBIRTH; NDEATH + disconnect on offline).
 - **Payload Tooling**: Encode and decode Sparkplug B protobuf payloads, build metrics via `SparkplugMetricBuilder`, and build/parse topics safely.
 - **Spec-Aware Lifecycle**: Optional NDEATH Last Will and Testament (LWT) for spec-compliant session awareness on ungraceful disconnect.
 - **Validation Controls**: Optional strict identifier validation to reject invalid topic IDs (`#`, `+`) for Group, Edge Node, Device, and Host IDs.

--- a/Tests/HiveMQtt.Sparkplug.Test/EdgeNode/SparkplugEdgeNodeOptionsTest.cs
+++ b/Tests/HiveMQtt.Sparkplug.Test/EdgeNode/SparkplugEdgeNodeOptionsTest.cs
@@ -31,6 +31,7 @@ public class SparkplugEdgeNodeOptionsTest
         options.SparkplugNamespace.Should().Be(SparkplugTopic.DefaultNamespace);
         options.GroupId.Should().BeNull();
         options.EdgeNodeId.Should().BeNull();
+        options.PrimaryHostApplicationId.Should().BeNull();
         options.UseDeathLwt.Should().BeTrue();
     }
 
@@ -136,5 +137,36 @@ public class SparkplugEdgeNodeOptionsTest
         Action act = options.Validate;
 
         act.Should().Throw<ArgumentException>().WithMessage("*Edge Node*'+'*");
+    }
+
+    [Test]
+    public void Validate_With_PrimaryHostApplicationId_Does_Not_Require_It()
+    {
+        var options = new SparkplugEdgeNodeOptions
+        {
+            GroupId = "g1",
+            EdgeNodeId = "n1",
+            PrimaryHostApplicationId = null,
+        };
+
+        Action act = options.Validate;
+
+        act.Should().NotThrow();
+    }
+
+    [Test]
+    public void Validate_With_StrictIdentifierValidation_And_PrimaryHostApplicationId_With_Hash_Throws()
+    {
+        var options = new SparkplugEdgeNodeOptions
+        {
+            GroupId = "g1",
+            EdgeNodeId = "n1",
+            PrimaryHostApplicationId = "host#1",
+            StrictIdentifierValidation = true,
+        };
+
+        Action act = options.Validate;
+
+        act.Should().Throw<ArgumentException>();
     }
 }

--- a/Tests/HiveMQtt.Sparkplug.Test/EdgeNode/SparkplugEdgeNodeTest.cs
+++ b/Tests/HiveMQtt.Sparkplug.Test/EdgeNode/SparkplugEdgeNodeTest.cs
@@ -14,7 +14,10 @@
 
 namespace HiveMQtt.Sparkplug.Test.EdgeNode;
 
+using System;
 using System.Linq;
+using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using HiveMQtt.Client;
@@ -400,5 +403,251 @@ public class SparkplugEdgeNodeTest
 
         await Task.Delay(100).ConfigureAwait(false);
         commandEvents.Should().Be(1, "message handler should be wired exactly once after retrying StartAsync.");
+    }
+
+    [Test]
+    public async Task StartAsync_With_PrimaryHost_Subscribes_To_Exact_State_Topic_And_Waits_For_Online()
+    {
+        var client = new FakeHiveMQClient();
+        var onlineTs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        client.AfterSubscribeCallback = (c, _) =>
+        {
+            c.SimulateMessageReceived(
+                "spBv1.0/STATE/host1",
+                SparkplugStatePayload.CreateOnline(onlineTs).ToUtf8Bytes());
+        };
+
+        SparkplugMessageReceivedEventArgs? stateArgs = null;
+        var options = new SparkplugEdgeNodeOptions
+        {
+            GroupId = "g1",
+            EdgeNodeId = "n1",
+            PrimaryHostApplicationId = "host1",
+        };
+        var node = new SparkplugEdgeNode(client, options);
+        node.StateMessageReceived += (_, e) => stateArgs = e;
+
+        await node.StartAsync().ConfigureAwait(false);
+
+        node.IsConnected.Should().BeTrue();
+        node.IsPrimaryHostOnline.Should().BeTrue();
+        client.Subscriptions.Should().HaveCount(3);
+        client.Subscriptions.Select(s => s.TopicFilter.Topic).Should().Contain("spBv1.0/STATE/host1");
+        client.PublishedMessages.Should().ContainSingle(m => m.Topic == "spBv1.0/g1/NBIRTH/n1");
+        stateArgs.Should().NotBeNull();
+        stateArgs!.PrimaryHostId.Should().Be("host1");
+        stateArgs.StatePayload!.Online.Should().BeTrue();
+        stateArgs.StatePayload.Timestamp.Should().Be(onlineTs);
+    }
+
+    [Test]
+    public async Task StartAsync_With_PrimaryHost_Does_Not_Publish_NBirth_While_Host_Offline()
+    {
+        var client = new FakeHiveMQClient();
+        client.AfterSubscribeCallback = (c, _) =>
+        {
+            c.SimulateMessageReceived(
+                "spBv1.0/STATE/host1",
+                SparkplugStatePayload.CreateOffline(timestampMs: 1).ToUtf8Bytes());
+        };
+
+        var options = new SparkplugEdgeNodeOptions
+        {
+            GroupId = "g1",
+            EdgeNodeId = "n1",
+            PrimaryHostApplicationId = "host1",
+        };
+        var node = new SparkplugEdgeNode(client, options);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(200));
+        Func<Task> act = () => node.StartAsync(cancellationToken: cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>().ConfigureAwait(false);
+        client.PublishedMessages.Should().NotContain(m => m.Topic == "spBv1.0/g1/NBIRTH/n1");
+        node.IsConnected.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task PrimaryHost_Valid_Offline_Publishes_NDeath_And_Disconnects()
+    {
+        var client = new FakeHiveMQClient();
+        var onlineTs = 1000L;
+        client.AfterSubscribeCallback = (c, _) =>
+        {
+            c.SimulateMessageReceived(
+                "spBv1.0/STATE/host1",
+                SparkplugStatePayload.CreateOnline(onlineTs).ToUtf8Bytes());
+        };
+
+        var options = new SparkplugEdgeNodeOptions
+        {
+            GroupId = "g1",
+            EdgeNodeId = "n1",
+            PrimaryHostApplicationId = "host1",
+        };
+        var node = new SparkplugEdgeNode(client, options);
+        await node.StartAsync().ConfigureAwait(false);
+        client.PublishedMessages.Clear();
+
+        client.SimulateMessageReceived(
+            "spBv1.0/STATE/host1",
+            SparkplugStatePayload.CreateOffline(timestampMs: onlineTs + 1).ToUtf8Bytes());
+
+        await WaitUntilAsync(() => !node.IsConnected && client.PublishedMessages.Any(m => m.Topic == "spBv1.0/g1/NDEATH/n1")).ConfigureAwait(false);
+
+        node.IsConnected.Should().BeFalse();
+        node.IsPrimaryHostOnline.Should().BeFalse();
+        client.PublishedMessages.Should().Contain(m => m.Topic == "spBv1.0/g1/NDEATH/n1");
+        client.IsConnected().Should().BeFalse();
+    }
+
+    [Test]
+    public async Task PrimaryHost_Stale_Offline_Does_Not_Terminate_Session()
+    {
+        var client = new FakeHiveMQClient();
+        var onlineTs = 2000L;
+        client.AfterSubscribeCallback = (c, _) =>
+        {
+            c.SimulateMessageReceived(
+                "spBv1.0/STATE/host1",
+                SparkplugStatePayload.CreateOnline(onlineTs).ToUtf8Bytes());
+        };
+
+        var options = new SparkplugEdgeNodeOptions
+        {
+            GroupId = "g1",
+            EdgeNodeId = "n1",
+            PrimaryHostApplicationId = "host1",
+        };
+        var node = new SparkplugEdgeNode(client, options);
+        await node.StartAsync().ConfigureAwait(false);
+        client.PublishedMessages.Clear();
+
+        client.SimulateMessageReceived(
+            "spBv1.0/STATE/host1",
+            SparkplugStatePayload.CreateOffline(timestampMs: onlineTs - 1).ToUtf8Bytes());
+
+        await Task.Delay(150).ConfigureAwait(false);
+
+        node.IsConnected.Should().BeTrue();
+        client.PublishedMessages.Should().NotContain(m => m.Topic == "spBv1.0/g1/NDEATH/n1");
+        client.IsConnected().Should().BeTrue();
+    }
+
+    [Test]
+    public async Task PrimaryHost_Ignores_State_For_Different_Host_Id()
+    {
+        var client = new FakeHiveMQClient();
+        client.AfterSubscribeCallback = (c, _) =>
+        {
+            c.SimulateMessageReceived(
+                "spBv1.0/STATE/host1",
+                SparkplugStatePayload.CreateOnline(1000).ToUtf8Bytes());
+        };
+
+        var stateEvents = 0;
+        var options = new SparkplugEdgeNodeOptions
+        {
+            GroupId = "g1",
+            EdgeNodeId = "n1",
+            PrimaryHostApplicationId = "host1",
+        };
+        var node = new SparkplugEdgeNode(client, options);
+        node.StateMessageReceived += (_, _) => stateEvents++;
+        await node.StartAsync().ConfigureAwait(false);
+        stateEvents.Should().Be(1);
+
+        client.SimulateMessageReceived(
+            "spBv1.0/STATE/otherHost",
+            SparkplugStatePayload.CreateOffline(timestampMs: 9999).ToUtf8Bytes());
+
+        await Task.Delay(100).ConfigureAwait(false);
+
+        stateEvents.Should().Be(1);
+        node.IsConnected.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task PrimaryHost_Invalid_State_Json_Raises_MessageParseError()
+    {
+        var client = new FakeHiveMQClient();
+        client.AfterSubscribeCallback = (c, _) =>
+        {
+            c.SimulateMessageReceived(
+                "spBv1.0/STATE/host1",
+                SparkplugStatePayload.CreateOnline(1000).ToUtf8Bytes());
+        };
+
+        SparkplugMessageParseErrorEventArgs? error = null;
+        var options = new SparkplugEdgeNodeOptions
+        {
+            GroupId = "g1",
+            EdgeNodeId = "n1",
+            PrimaryHostApplicationId = "host1",
+        };
+        var node = new SparkplugEdgeNode(client, options);
+        node.MessageParseError += (_, e) => error = e;
+        await node.StartAsync().ConfigureAwait(false);
+
+        client.SimulateMessageReceived("spBv1.0/STATE/host1", Encoding.UTF8.GetBytes("not-json"));
+
+        await Task.Delay(50).ConfigureAwait(false);
+
+        error.Should().NotBeNull();
+        error!.Reason.Should().Contain("STATE payload is not valid Sparkplug 3.0 JSON");
+        node.IsConnected.Should().BeTrue();
+    }
+
+    [Test]
+    public async Task PrimaryHost_Can_Restart_After_Offline_When_Host_Returns_Online()
+    {
+        var client = new FakeHiveMQClient();
+        var deliverOnline = true;
+        client.AfterSubscribeCallback = (c, _) =>
+        {
+            if (deliverOnline)
+            {
+                c.SimulateMessageReceived(
+                    "spBv1.0/STATE/host1",
+                    SparkplugStatePayload.CreateOnline(3000).ToUtf8Bytes());
+            }
+        };
+
+        var options = new SparkplugEdgeNodeOptions
+        {
+            GroupId = "g1",
+            EdgeNodeId = "n1",
+            PrimaryHostApplicationId = "host1",
+        };
+        var node = new SparkplugEdgeNode(client, options);
+        await node.StartAsync().ConfigureAwait(false);
+
+        client.SimulateMessageReceived(
+            "spBv1.0/STATE/host1",
+            SparkplugStatePayload.CreateOffline(timestampMs: 3001).ToUtf8Bytes());
+        await WaitUntilAsync(() => !node.IsConnected).ConfigureAwait(false);
+
+        client.PublishedMessages.Clear();
+        deliverOnline = true;
+        await node.StartAsync().ConfigureAwait(false);
+
+        node.IsConnected.Should().BeTrue();
+        client.PublishedMessages.Should().Contain(m => m.Topic == "spBv1.0/g1/NBIRTH/n1");
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, int timeoutMs = 2000)
+    {
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            if (condition())
+            {
+                return;
+            }
+
+            await Task.Delay(20).ConfigureAwait(false);
+        }
+
+        condition().Should().BeTrue("condition should become true within timeout");
     }
 }

--- a/Tests/HiveMQtt.Sparkplug.Test/EdgeNode/SparkplugEdgeNodeTest.cs
+++ b/Tests/HiveMQtt.Sparkplug.Test/EdgeNode/SparkplugEdgeNodeTest.cs
@@ -635,6 +635,84 @@ public class SparkplugEdgeNodeTest
         client.PublishedMessages.Should().Contain(m => m.Topic == "spBv1.0/g1/NBIRTH/n1");
     }
 
+    [Test]
+    public async Task PrimaryHost_Offline_During_NBirth_Aborts_Start_With_NDeath()
+    {
+        var client = new FakeHiveMQClient();
+        var onlineTs = 4000L;
+        client.AfterSubscribeCallback = (c, _) =>
+        {
+            c.SimulateMessageReceived(
+                "spBv1.0/STATE/host1",
+                SparkplugStatePayload.CreateOnline(onlineTs).ToUtf8Bytes());
+        };
+        client.BeforePublishCallback = (c, message) =>
+        {
+            if (message.Topic == "spBv1.0/g1/NBIRTH/n1")
+            {
+                c.SimulateMessageReceived(
+                    "spBv1.0/STATE/host1",
+                    SparkplugStatePayload.CreateOffline(timestampMs: onlineTs + 1).ToUtf8Bytes());
+            }
+        };
+
+        var options = new SparkplugEdgeNodeOptions
+        {
+            GroupId = "g1",
+            EdgeNodeId = "n1",
+            PrimaryHostApplicationId = "host1",
+        };
+        var node = new SparkplugEdgeNode(client, options);
+
+        Func<Task> act = () => node.StartAsync();
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Primary Host went offline*")
+            .ConfigureAwait(false);
+
+        node.IsConnected.Should().BeFalse();
+        node.IsPrimaryHostOnline.Should().BeFalse();
+        client.PublishedMessages.Should().Contain(m => m.Topic == "spBv1.0/g1/NBIRTH/n1");
+        client.PublishedMessages.Should().Contain(m => m.Topic == "spBv1.0/g1/NDEATH/n1");
+    }
+
+    [Test]
+    public async Task PrimaryHost_Regressive_Online_Timestamp_Does_Not_Allow_Stale_Offline_Termination()
+    {
+        var client = new FakeHiveMQClient();
+        var onlineTs = 2000L;
+        client.AfterSubscribeCallback = (c, _) =>
+        {
+            c.SimulateMessageReceived(
+                "spBv1.0/STATE/host1",
+                SparkplugStatePayload.CreateOnline(onlineTs).ToUtf8Bytes());
+        };
+
+        var options = new SparkplugEdgeNodeOptions
+        {
+            GroupId = "g1",
+            EdgeNodeId = "n1",
+            PrimaryHostApplicationId = "host1",
+        };
+        var node = new SparkplugEdgeNode(client, options);
+        await node.StartAsync().ConfigureAwait(false);
+        client.PublishedMessages.Clear();
+
+        // Regressive online must not lower the watermark; offline with ts between old and new must be ignored.
+        client.SimulateMessageReceived(
+            "spBv1.0/STATE/host1",
+            SparkplugStatePayload.CreateOnline(1).ToUtf8Bytes());
+        client.SimulateMessageReceived(
+            "spBv1.0/STATE/host1",
+            SparkplugStatePayload.CreateOffline(timestampMs: 2).ToUtf8Bytes());
+
+        await Task.Delay(150).ConfigureAwait(false);
+
+        node.IsConnected.Should().BeTrue();
+        client.PublishedMessages.Should().NotContain(m => m.Topic == "spBv1.0/g1/NDEATH/n1");
+        client.IsConnected().Should().BeTrue();
+    }
+
     private static async Task WaitUntilAsync(Func<bool> condition, int timeoutMs = 2000)
     {
         var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);

--- a/Tests/HiveMQtt.Sparkplug.Test/HostApplication/FakeHiveMQClient.cs
+++ b/Tests/HiveMQtt.Sparkplug.Test/HostApplication/FakeHiveMQClient.cs
@@ -53,6 +53,12 @@ internal sealed class FakeHiveMQClient : IHiveMQClient
 
     public Func<MQTT5PublishMessage, Exception?>? PublishFailureFactory { get; set; }
 
+    /// <summary>
+    /// Gets or sets an optional callback invoked after subscriptions are recorded and before <see cref="SubscribeAsync(SubscribeOptions)"/> returns.
+    /// Useful for delivering retained messages (e.g. Primary Host STATE) while the Edge Node is waiting for online.
+    /// </summary>
+    public Action<FakeHiveMQClient, SubscribeOptions>? AfterSubscribeCallback { get; set; }
+
     public bool IsConnected() => this.connected && !this.disposed;
 
     public Task<ConnectResult> ConnectAsync(ConnectOptions? connectOptions = null)
@@ -122,6 +128,8 @@ internal sealed class FakeHiveMQClient : IHiveMQClient
         {
             this.Subscriptions.Add(sub);
         }
+
+        this.AfterSubscribeCallback?.Invoke(this, options);
 
         return Task.FromResult(result);
     }

--- a/Tests/HiveMQtt.Sparkplug.Test/HostApplication/FakeHiveMQClient.cs
+++ b/Tests/HiveMQtt.Sparkplug.Test/HostApplication/FakeHiveMQClient.cs
@@ -59,6 +59,12 @@ internal sealed class FakeHiveMQClient : IHiveMQClient
     /// </summary>
     public Action<FakeHiveMQClient, SubscribeOptions>? AfterSubscribeCallback { get; set; }
 
+    /// <summary>
+    /// Gets or sets an optional callback invoked before a publish is recorded.
+    /// Useful for simulating Primary Host STATE changes during NBIRTH publish.
+    /// </summary>
+    public Action<FakeHiveMQClient, MQTT5PublishMessage>? BeforePublishCallback { get; set; }
+
     public bool IsConnected() => this.connected && !this.disposed;
 
     public Task<ConnectResult> ConnectAsync(ConnectOptions? connectOptions = null)
@@ -77,6 +83,8 @@ internal sealed class FakeHiveMQClient : IHiveMQClient
 
     public Task<PublishResult> PublishAsync(MQTT5PublishMessage message, CancellationToken cancellationToken = default)
     {
+        this.BeforePublishCallback?.Invoke(this, message);
+
         var publishFailure = this.PublishFailureFactory?.Invoke(message);
         if (publishFailure != null)
         {


### PR DESCRIPTION
## Summary
- Add opt-in `PrimaryHostApplicationId` on `SparkplugEdgeNodeOptions` for single-broker Primary Host Application behavior
- When set: subscribe to exact `STATE/{id}`, wait for online before NBIRTH, raise `StateMessageReceived`, expose `IsPrimaryHostOnline`, and on valid offline publish NDEATH + disconnect
- Default (unset) keeps existing Edge Node behavior for current customers
- Docs and unit tests for wait/online, stale offline, wrong host id, and restart after offline

Fixes #362

Note: This is full Primary Host support (not the customer fork's always-on `STATE/#` + event-only approach). Multi-MQTT-server cycling remains out of scope.

## Test plan
- [ ] `dotnet test Tests/HiveMQtt.Sparkplug.Test --filter FullyQualifiedName~SparkplugEdgeNode`
- [ ] CI green on PR
- [ ] Verify with broker: Edge with Primary Host waits for retained online STATE before NBIRTH
- [ ] Verify valid offline STATE causes NDEATH + disconnect; stale offline is ignored