### PR TITLE
Enable Native AOT (IsAotCompatible) support

### DIFF
--- a/Documentation/docs/hivemqtt/how-to/configure-logging.md
+++ b/Documentation/docs/hivemqtt/how-to/configure-logging.md
@@ -53,6 +53,11 @@ Setting `minlevel` to `Trace` will output all activity in the HiveMQtt package d
 2024-03-14 15:40:18.2775|TRACE|HiveMQtt.Client.HiveMQClient|AfterConnectEventLauncher
 ```
 
+## Native AOT
+
+When publishing with Native AOT (`PublishAot`), XML `NLog.config` alone may not keep File/Console targets from being trimmed. Register those targets in code (see [Native AOT](/docs/hivemqtt/how-to/native-aot)) so configuration continues to work after publish.
+
 ## See Also
 
 * [NLog](https://github.com/NLog/NLog)
+* [Native AOT](/docs/hivemqtt/how-to/native-aot)

--- a/Documentation/docs/hivemqtt/how-to/native-aot.md
+++ b/Documentation/docs/hivemqtt/how-to/native-aot.md
@@ -42,7 +42,7 @@ See [Configure Logging](/docs/hivemqtt/how-to/configure-logging) for the full NL
 
 ## Sparkplug and Google.Protobuf
 
-`HiveMQtt.Sparkplug` is also marked `IsAotCompatible`. Protobuf encode/decode of Sparkplug payloads is exercised under Native AOT publish, but [Google.Protobuf is not officially AOT-certified](https://github.com/protocolbuffers/protobuf/issues/25574). Treat Sparkplug AOT support as **best-effort** relative to that dependency.
+`HiveMQtt.Sparkplug` is also marked `IsAotCompatible` (trim/AOT analyzers are clean on net8.0+). [Google.Protobuf is not officially AOT-certified](https://github.com/protocolbuffers/protobuf/issues/25574), so treat Sparkplug AOT support as **best-effort** relative to that dependency. Validate `PublishAot` in your own application.
 
 ## See Also
 

--- a/Documentation/docs/hivemqtt/how-to/native-aot.md
+++ b/Documentation/docs/hivemqtt/how-to/native-aot.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 11
+---
+
+# Native AOT
+
+HiveMQtt and HiveMQtt.Sparkplug are marked [`IsAotCompatible`](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/) for **.NET 8.0 and later**. That enables trim, single-file, and AOT analyzers during the library build and advertises Native AOT readiness to consumers.
+
+## Publish your app with Native AOT
+
+In your **application** project (not the library):
+
+```xml
+<PropertyGroup>
+  <TargetFramework>net8.0</TargetFramework>
+  <PublishAot>true</PublishAot>
+</PropertyGroup>
+```
+
+Then publish for a specific runtime identifier:
+
+```bash
+dotnet publish -c Release -r osx-arm64
+# or linux-x64, win-x64, etc.
+```
+
+You do **not** set `IsAotCompatible` in your app — that property is for libraries.
+
+## Logging under Native AOT
+
+HiveMQtt uses [NLog 6](https://nlog-project.org/2025/06/21/nlog-6-0-released.html), which supports AOT. If you load logging from an XML `NLog.config`, the AOT/trimmer cannot see target types referenced only by `xsi:type`. Register the targets your config uses before logging starts:
+
+```csharp
+NLog.LogManager.Setup().SetupExtensions(ext =>
+{
+    ext.RegisterTarget<NLog.Targets.FileTarget>();
+    ext.RegisterTarget<NLog.Targets.ConsoleTarget>();
+});
+```
+
+See [Configure Logging](/docs/hivemqtt/how-to/configure-logging) for the full NLog setup.
+
+## Sparkplug and Google.Protobuf
+
+`HiveMQtt.Sparkplug` is also marked `IsAotCompatible`. Protobuf encode/decode of Sparkplug payloads is exercised under Native AOT publish, but [Google.Protobuf is not officially AOT-certified](https://github.com/protocolbuffers/protobuf/issues/25574). Treat Sparkplug AOT support as **best-effort** relative to that dependency.
+
+## See Also
+
+* [Native AOT deployment overview](https://learn.microsoft.com/en-us/dotnet/core/deploying/native-aot/)
+* [Configure Logging](/docs/hivemqtt/how-to/configure-logging)
+* [Creating AOT-compatible libraries](https://devblogs.microsoft.com/dotnet/creating-aot-compatible-libraries/)

--- a/Documentation/docs/hivemqtt/intro.md
+++ b/Documentation/docs/hivemqtt/intro.md
@@ -28,6 +28,7 @@ The Sparkplug client is documented separately. Start with [HiveMQtt.Sparkplug](/
 | **NuGet Package** | [HiveMQtt](https://www.nuget.org/packages/HiveMQtt) |
 | **MQTT Version** | Full [MQTT 5.0](https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html) compliance |
 | **.NET Support** | .NET 6.0, 7.0, 8.0, 9.0 & 10.0 |
+| **Native AOT** | Compatible on .NET 8.0+ (`IsAotCompatible`). See [Native AOT](/docs/hivemqtt/how-to/native-aot). |
 | **License** | Apache 2.0 (Open Source) |
 
 ## Key Features

--- a/Documentation/docs/sparkplug/intro.md
+++ b/Documentation/docs/sparkplug/intro.md
@@ -26,6 +26,7 @@ Then continue with the [Sparkplug Quickstart](/docs/sparkplug/quickstart).
 | **Depends On** | [HiveMQtt](https://www.nuget.org/packages/HiveMQtt) |
 | **Sparkplug Version** | [Sparkplug B 3.0](https://sparkplug.eclipse.org/specification/version/3.0) |
 | **.NET Support** | .NET 6.0, 7.0, 8.0, 9.0 and 10.0 |
+| **Native AOT** | Compatible on .NET 8.0+ (`IsAotCompatible`). `Google.Protobuf` is best-effort (not officially AOT-certified). See [Native AOT](/docs/hivemqtt/how-to/native-aot). |
 | **Status** | Beta |
 
 ## What You Can Build

--- a/Documentation/docs/sparkplug/intro.md
+++ b/Documentation/docs/sparkplug/intro.md
@@ -26,7 +26,7 @@ Then continue with the [Sparkplug Quickstart](/docs/sparkplug/quickstart).
 | **Depends On** | [HiveMQtt](https://www.nuget.org/packages/HiveMQtt) |
 | **Sparkplug Version** | [Sparkplug B 3.0](https://sparkplug.eclipse.org/specification/version/3.0) |
 | **.NET Support** | .NET 6.0, 7.0, 8.0, 9.0 and 10.0 |
-| **Native AOT** | Compatible on .NET 8.0+ (`IsAotCompatible`). `Google.Protobuf` is best-effort (not officially AOT-certified). See [Native AOT](/docs/hivemqtt/how-to/native-aot). |
+| **Native AOT** | Analyzer-clean on .NET 8.0+ (`IsAotCompatible`). `Google.Protobuf` payload support is best-effort (not officially AOT-certified). See [Native AOT](/docs/hivemqtt/how-to/native-aot). |
 | **Status** | Beta |
 
 ## What You Can Build

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 * **Easy-to-Install**: Available as a [NuGet package](https://www.nuget.org/packages/HiveMQtt).
 * **Globally Compatible**: Built to be a fully compliant MQTT 5.0 client compatible with all modern MQTT brokers.
 * **Multi-Targeted**: Supports .NET 6.0, 7.0, 8.0, 9.0 & 10.0
+* **Native AOT**: Marked `IsAotCompatible` for .NET 8.0 and later. See the [Native AOT guide](https://hivemq.github.io/hivemq-mqtt-client-dotnet/docs/hivemqtt/how-to/native-aot).
 * **Sparkplug Client extension**: The [HiveMQtt.Sparkplug](https://www.nuget.org/packages/HiveMQtt.Sparkplug) package adds Host Application and Edge Node support for industrial IoT (IIoT) using the [Eclipse Sparkplug B 3.0](https://sparkplug.eclipse.org/specification/version/3.0) specification—install with `dotnet add package HiveMQtt.Sparkplug` and see the [Sparkplug README](./Source/HiveMQtt.Sparkplug/README.md) for full details.
 
 ### 🚀 Features

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -5,6 +5,9 @@
   <PropertyGroup Label="Build">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!-- Native AOT: enable analyzers and metadata for net8.0+ (attributes incomplete before net8). -->
+    <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
+    <WarningsAsErrors Condition="'$(IsAotCompatible)' == 'true'">$(WarningsAsErrors);IL2026;IL3050;IL3051</WarningsAsErrors>
   </PropertyGroup>
 
   <PropertyGroup Label="Signing">

--- a/Source/HiveMQtt.Sparkplug/HostApplication/SparkplugStatePayload.cs
+++ b/Source/HiveMQtt.Sparkplug/HostApplication/SparkplugStatePayload.cs
@@ -16,6 +16,7 @@ namespace HiveMQtt.Sparkplug.HostApplication;
 
 using System;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 /// <summary>
 /// Sparkplug 3.0 STATE message payload. STATE messages use JSON format:
@@ -23,12 +24,6 @@ using System.Text.Json;
 /// </summary>
 public sealed class SparkplugStatePayload
 {
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        WriteIndented = false,
-    };
-
     /// <summary>
     /// Tries to decode a STATE message payload from UTF-8 JSON bytes (Sparkplug 3.0 format).
     /// </summary>
@@ -45,7 +40,7 @@ public sealed class SparkplugStatePayload
 
         try
         {
-            var obj = JsonSerializer.Deserialize<JsonPayload>(data, JsonOptions);
+            var obj = JsonSerializer.Deserialize(data, SparkplugStateJsonContext.Default.SparkplugStateJsonPayload);
             if (obj is null)
             {
                 return false;
@@ -106,14 +101,28 @@ public sealed class SparkplugStatePayload
     /// <returns>The JSON payload as UTF-8 bytes.</returns>
     public byte[] ToUtf8Bytes()
     {
-        var obj = new JsonPayload { Online = this.Online, Timestamp = this.Timestamp };
-        return JsonSerializer.SerializeToUtf8Bytes(obj, JsonOptions);
+        var obj = new SparkplugStateJsonPayload { Online = this.Online, Timestamp = this.Timestamp };
+        return JsonSerializer.SerializeToUtf8Bytes(obj, SparkplugStateJsonContext.Default.SparkplugStateJsonPayload);
     }
+}
 
-    private sealed class JsonPayload
-    {
-        public bool Online { get; set; }
+/// <summary>
+/// DTO for Sparkplug STATE JSON serialization (source-generated for Native AOT).
+/// </summary>
+internal sealed class SparkplugStateJsonPayload
+{
+    public bool Online { get; set; }
 
-        public long Timestamp { get; set; }
-    }
+    public long Timestamp { get; set; }
+}
+
+/// <summary>
+/// AOT-compatible JSON serializer context for Sparkplug STATE payloads.
+/// </summary>
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    WriteIndented = false)]
+[JsonSerializable(typeof(SparkplugStateJsonPayload))]
+internal partial class SparkplugStateJsonContext : JsonSerializerContext
+{
 }

--- a/Source/HiveMQtt.Sparkplug/README.md
+++ b/Source/HiveMQtt.Sparkplug/README.md
@@ -23,6 +23,7 @@ Sparkplug B 3.0 extension for the [HiveMQ MQTT Client for .NET](https://github.c
 - **Easy-to-Install**: Available as a [NuGet package](https://www.nuget.org/packages/HiveMQtt.Sparkplug).
 - **Built for IIoT**: Adds Sparkplug Host Application and Edge Node workflows on top of `HiveMQtt`.
 - **Multi-Targeted**: Supports .NET 6.0, 7.0, 8.0, 9.0 and 10.0.
+- **Native AOT**: Marked `IsAotCompatible` for .NET 8.0 and later. `Google.Protobuf` payload support is best-effort (not officially AOT-certified by Google).
 - **Standards-Based**: Aligned with [Eclipse Sparkplug B 3.0](https://sparkplug.eclipse.org/specification/version/3.0) and `sparkplug_b.proto`.
 - **Status**: This extension is in **beta**. APIs may change before stable release.
 

--- a/Source/HiveMQtt/HiveMQtt.csproj
+++ b/Source/HiveMQtt/HiveMQtt.csproj
@@ -70,7 +70,6 @@
     <PackageReference Include="System.IO.Pipelines" Version="10.0.11" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
     <PackageReference Include="NLog" Version="6.2.0" />
-    <PackageReference Include="Websocket.Client" Version="5.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/HiveMQtt.Sparkplug.Test/HostApplication/SparkplugStatePayloadTest.cs
+++ b/Tests/HiveMQtt.Sparkplug.Test/HostApplication/SparkplugStatePayloadTest.cs
@@ -1,0 +1,46 @@
+// Copyright 2026-present HiveMQ and the HiveMQ Community
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace HiveMQtt.Sparkplug.Test.HostApplication;
+
+using System.Text;
+using FluentAssertions;
+using HiveMQtt.Sparkplug.HostApplication;
+using NUnit.Framework;
+
+[TestFixture]
+public class SparkplugStatePayloadTest
+{
+    [Test]
+    public void ToUtf8Bytes_Uses_Sparkplug_CamelCase_Wire_Format()
+    {
+        var online = new SparkplugStatePayload(online: true, timestamp: 1710000000000);
+        Encoding.UTF8.GetString(online.ToUtf8Bytes())
+            .Should().Be("{\"online\":true,\"timestamp\":1710000000000}");
+
+        var offline = SparkplugStatePayload.CreateOffline(timestampMs: 0);
+        Encoding.UTF8.GetString(offline.ToUtf8Bytes())
+            .Should().Be("{\"online\":false,\"timestamp\":0}");
+    }
+
+    [Test]
+    public void TryDecode_Reads_Spec_CamelCase_Json()
+    {
+        var bytes = Encoding.UTF8.GetBytes("{\"online\":true,\"timestamp\":1710000000000}");
+
+        SparkplugStatePayload.TryDecode(bytes, out var payload).Should().BeTrue();
+        payload!.Online.Should().BeTrue();
+        payload.Timestamp.Should().Be(1710000000000);
+    }
+}


### PR DESCRIPTION
## Summary
- Marks HiveMQtt and HiveMQtt.Sparkplug as `IsAotCompatible` for net8.0+ (enables trim/AOT/single-file analyzers; treats IL2026/IL3050/IL3051 as errors)
- Makes Sparkplug STATE JSON AOT-safe via `JsonSerializerContext` source generation; removes unused `Websocket.Client` dependency
- Documents Native AOT publish usage, NLog XML target registration under AOT, and Sparkplug/`Google.Protobuf` best-effort caveat

Closes #371

## Release notes
- **Native AOT:** HiveMQtt and HiveMQtt.Sparkplug advertise `IsAotCompatible` on .NET 8.0+. Sparkplug AOT is analyzer-clean; `Google.Protobuf` remains best-effort (not officially AOT-certified). Validate `PublishAot` in your app.
- **Websocket.Client:** HiveMQtt no longer references the unused `Websocket.Client` package (transport uses `ClientWebSocket`). If your project compiled against `Websocket.Client` types without its own `PackageReference`, add `dotnet add package Websocket.Client`.

## Test plan
- [x] `dotnet build Source/HiveMQtt/HiveMQtt.csproj -c Release -f net8.0` (no IL2026/IL3050/IL3051)
- [x] `dotnet build Source/HiveMQtt.Sparkplug/HiveMQtt.Sparkplug.csproj -c Release -f net8.0` (no IL AOT errors)
- [ ] Optional: `PublishAot` smoke console app referencing both packages for a local RID
- [x] Confirm Sparkplug STATE encode/decode still works (existing tests + camelCase wire-format asserts)
- [x] Skim new Native AOT how-to and logging note for accuracy