### PR TITLE
Fix PacketIDManager FreedPacketIds memory leak (#379)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,17 +23,18 @@ jobs:
 
     services:
       hivemq:
+        # Keep latest for CI; healthcheck probes MQTT (1883), not Control Center (8080).
+        # WebSocket tests use 8000. 8080 is Control Center only and is unused by this suite.
         image: hivemq/hivemq4:latest
         ports:
           - 1883:1883
           - 8000:8000
-          - 8080:8080
         options: >-
-          --health-cmd "curl -I http://localhost:8080/"
+          --health-cmd "bash -c 'exec 3<>/dev/tcp/127.0.0.1/1883'"
           --health-interval 10s
           --health-timeout 5s
-          --health-retries 10
-          --health-start-period 30s
+          --health-retries 12
+          --health-start-period 60s
 
     strategy:
       matrix:

--- a/Source/HiveMQtt/Client/Connection/ConnectionManagerHandlers.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManagerHandlers.cs
@@ -30,6 +30,7 @@ public partial class ConnectionManager
         {
             this.IPubTransactionQueue.Clear();
             this.OPubTransactionQueue.Clear();
+            this.PacketIDManager.Reset();
 
             // Session is not present on the broker; clear local subscription tracking
             _ = this.Client.ClearSubscriptionsAsync();
@@ -111,7 +112,6 @@ public partial class ConnectionManager
                     {
                         Logger.Error($"QoS1: Couldn't update Publish --> PubAck QoS1 Chain for packet identifier {publishPacket.PacketIdentifier}. Discarded.");
                         this.IPubTransactionQueue.Remove(publishPacket.PacketIdentifier, out _);
-                        await this.PacketIDManager.MarkPacketIDAsAvailableAsync(publishPacket.PacketIdentifier).ConfigureAwait(false);
 
                         var opts = new DisconnectOptions
                         {
@@ -129,7 +129,6 @@ public partial class ConnectionManager
                         ReasonString = "Client internal error managing publish transaction chain.",
                     };
                     await this.Client.DisconnectAsync(opts).ConfigureAwait(false);
-                    await this.PacketIDManager.MarkPacketIDAsAvailableAsync(publishPacket.PacketIdentifier).ConfigureAwait(false);
                     Logger.Error($"QoS1: Received Publish with an unknown packet identifier {publishPacket.PacketIdentifier}.");
                 }
             }
@@ -162,7 +161,6 @@ public partial class ConnectionManager
                     {
                         Logger.Error($"QoS2: Couldn't update Publish --> PubRec QoS2 Chain for packet identifier {publishPacket.PacketIdentifier}. Discarded.");
                         this.IPubTransactionQueue.Remove(publishPacket.PacketIdentifier, out _);
-                        await this.PacketIDManager.MarkPacketIDAsAvailableAsync(publishPacket.PacketIdentifier).ConfigureAwait(false);
                     }
                 }
                 else
@@ -173,7 +171,6 @@ public partial class ConnectionManager
                         ReasonString = "Client internal error managing publish transaction chain.",
                     };
                     await this.Client.DisconnectAsync(opts).ConfigureAwait(false);
-                    await this.PacketIDManager.MarkPacketIDAsAvailableAsync(publishPacket.PacketIdentifier).ConfigureAwait(false);
                     Logger.Error($"QoS2: Received Publish with an unknown packet identifier {publishPacket.PacketIdentifier}.");
                 }
 
@@ -299,11 +296,12 @@ public partial class ConnectionManager
     }
 
     /// <summary>
-    /// Handle an incoming PubComp packet.
+    /// Handle a sent PubAck packet (completes an incoming QoS 1 publish).
+    /// Broker-assigned incoming packet IDs are not tracked by PacketIDManager.
     /// </summary>
-    /// <param name="pubAckPacket">The received PubComp packet.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    internal async Task HandleSentPubAckPacketAsync(PubAckPacket pubAckPacket)
+    /// <param name="pubAckPacket">The sent PubAck packet.</param>
+    /// <returns>A completed task.</returns>
+    internal Task HandleSentPubAckPacketAsync(PubAckPacket pubAckPacket)
     {
         // Remove the transaction chain from the transaction queue
         var success = this.IPubTransactionQueue.Remove(pubAckPacket.PacketIdentifier, out var publishQoS1Chain);
@@ -328,19 +326,18 @@ public partial class ConnectionManager
             Logger.Warn($"QoS1: Couldn't remove PubAck --> Publish QoS1 Chain for packet identifier {pubAckPacket.PacketIdentifier}.");
         }
 
-        // QoS1 transaction is done.  Release the packet identifier
-        await this.PacketIDManager.MarkPacketIDAsAvailableAsync(pubAckPacket.PacketIdentifier).ConfigureAwait(false);
-
         // The Packet Event
         this.Client.OnPubAckSentEventLauncher(pubAckPacket);
+        return Task.CompletedTask;
     }
 
     /// <summary>
-    /// Action to take once a PubComp packet is sent.
+    /// Action to take once a PubComp packet is sent (completes an incoming QoS 2 publish).
+    /// Broker-assigned incoming packet IDs are not tracked by PacketIDManager.
     /// </summary>
     /// <param name="pubCompPacket">The sent PubComp packet.</param>
-    /// <returns>A task that represents the asynchronous operation.</returns>
-    internal async Task HandleSentPubCompPacketAsync(PubCompPacket pubCompPacket)
+    /// <returns>A completed task.</returns>
+    internal Task HandleSentPubCompPacketAsync(PubCompPacket pubCompPacket)
     {
         Logger.Trace($"{this.Client.Options.ClientId}-(RPH)- <-- Sent PubComp id={pubCompPacket.PacketIdentifier} reason={pubCompPacket.ReasonCode}");
 
@@ -364,11 +361,9 @@ public partial class ConnectionManager
             }
         }
 
-        // QoS2 transaction is done.  Release the packet identifier
-        await this.PacketIDManager.MarkPacketIDAsAvailableAsync(pubCompPacket.PacketIdentifier).ConfigureAwait(false);
-
         // Trigger the general event
         this.Client.OnPubCompSentEventLauncher(pubCompPacket);
+        return Task.CompletedTask;
     }
 
     /// <summary>

--- a/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
+++ b/Source/HiveMQtt/Client/Connection/ConnectionManagerTasks.cs
@@ -643,10 +643,12 @@ public partial class ConnectionManager
                     case SubAckPacket subAckPacket:
                         Logger.Trace($"{this.Client.Options.ClientId}-(RPH)- <-- Received SubAck id={subAckPacket.PacketIdentifier}");
                         this.Client.OnSubAckReceivedEventLauncher(subAckPacket);
+                        await this.PacketIDManager.MarkPacketIDAsAvailableAsync(subAckPacket.PacketIdentifier).ConfigureAwait(false);
                         break;
                     case UnsubAckPacket unsubAckPacket:
                         Logger.Trace($"{this.Client.Options.ClientId}-(RPH)- <-- Received UnsubAck id={unsubAckPacket.PacketIdentifier}");
                         this.Client.OnUnsubAckReceivedEventLauncher(unsubAckPacket);
+                        await this.PacketIDManager.MarkPacketIDAsAvailableAsync(unsubAckPacket.PacketIdentifier).ConfigureAwait(false);
                         break;
 
                     case PublishPacket publishPacket:

--- a/Source/HiveMQtt/Client/internal/PacketIDManager.cs
+++ b/Source/HiveMQtt/Client/internal/PacketIDManager.cs
@@ -196,7 +196,7 @@ public class PacketIDManager
     /// (CONNACK SessionPresent = false) so stale in-use bits and free-queue entries
     /// do not carry across connections.
     /// </summary>
-    public void Reset()
+    internal void Reset()
     {
         lock (this.bitArrayLock)
         {

--- a/Source/HiveMQtt/Client/internal/PacketIDManager.cs
+++ b/Source/HiveMQtt/Client/internal/PacketIDManager.cs
@@ -158,17 +158,24 @@ public class PacketIDManager
     /// Marks a packet ID as available and adds it to the reuse queue for immediate reuse.
     /// <para>
     /// Only IDs that are currently allocated are freed and enqueued. Freeing an ID that was
-    /// never allocated (or was already freed) is a no-op, preventing unbounded growth of the
-    /// reuse queue from stray frees of broker-assigned incoming packet IDs.
+    /// never allocated, already freed, or out of the valid MQTT range (1-65535) is a no-op,
+    /// preventing unbounded growth of the reuse queue and IndexOutOfRangeException from
+    /// stray or malformed identifiers.
     /// </para>
     /// <para>
     /// The method is synchronous but returns a Task for API compatibility.
     /// </para>
     /// </summary>
-    /// <param name="packetId">The packet ID to mark as available (must be in range 1-65535).</param>
+    /// <param name="packetId">The packet ID to mark as available (valid range 1-65535).</param>
     /// <returns>A completed Task representing the asynchronous operation.</returns>
     public Task MarkPacketIDAsAvailableAsync(int packetId)
     {
+        // MQTT packet identifiers are 1-65535; treat out-of-range as a no-op
+        if (packetId < 1 || packetId > 65535)
+        {
+            return Task.CompletedTask;
+        }
+
         lock (this.bitArrayLock)
         {
             if (this.PacketIDBitArray[packetId])

--- a/Source/HiveMQtt/Client/internal/PacketIDManager.cs
+++ b/Source/HiveMQtt/Client/internal/PacketIDManager.cs
@@ -7,6 +7,11 @@ using System.Threading;
 /// <summary>
 /// Manages MQTT packet identifiers with optimized lock-free operations for high-performance scenarios.
 /// <para>
+/// Tracks only client-allocated outgoing packet IDs (Publish, Subscribe, Unsubscribe).
+/// Broker-assigned incoming publish packet IDs use a separate MQTT ID space and must not be
+/// freed into this manager.
+/// </para>
+/// <para>
 /// This implementation uses a hybrid approach combining lock-free operations with minimal locking:
 /// - Lock-free operations: Packet ID counter updates, freed ID queue operations.
 /// - Minimal locking: Only for BitArray updates to ensure thread safety.
@@ -152,13 +157,9 @@ public class PacketIDManager
     /// <summary>
     /// Marks a packet ID as available and adds it to the reuse queue for immediate reuse.
     /// <para>
-    /// This method performs two operations:
-    /// 1. Updates the BitArray to mark the ID as available (requires lock).
-    /// 2. Enqueues the ID to the reuse queue (lock-free operation).
-    /// </para>
-    /// <para>
-    /// The freed ID will be immediately available for reuse in subsequent calls to
-    /// <see cref="GetAvailablePacketIDAsync"/>, improving performance by avoiding allocation overhead.
+    /// Only IDs that are currently allocated are freed and enqueued. Freeing an ID that was
+    /// never allocated (or was already freed) is a no-op, preventing unbounded growth of the
+    /// reuse queue from stray frees of broker-assigned incoming packet IDs.
     /// </para>
     /// <para>
     /// The method is synchronous but returns a Task for API compatibility.
@@ -168,20 +169,39 @@ public class PacketIDManager
     /// <returns>A completed Task representing the asynchronous operation.</returns>
     public Task MarkPacketIDAsAvailableAsync(int packetId)
     {
-        // Lock only for BitArray update
         lock (this.bitArrayLock)
         {
             if (this.PacketIDBitArray[packetId])
             {
                 this.PacketIDBitArray[packetId] = false;
                 Interlocked.Decrement(ref this.activeCount);
+
+                // Enqueue only when the ID was actually in use
+                this.FreedPacketIds.Enqueue(packetId);
             }
         }
 
-        // Lock-free enqueue to reuse queue
-        this.FreedPacketIds.Enqueue(packetId);
-
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Resets all packet ID tracking state. Used when a clean session is established
+    /// (CONNACK SessionPresent = false) so stale in-use bits and free-queue entries
+    /// do not carry across connections.
+    /// </summary>
+    public void Reset()
+    {
+        lock (this.bitArrayLock)
+        {
+            this.PacketIDBitArray.SetAll(false);
+            Interlocked.Exchange(ref this.activeCount, 0);
+            Interlocked.Exchange(ref this.nextPacketId, 1);
+
+            while (this.FreedPacketIds.TryDequeue(out _))
+            {
+                // Drain reuse queue
+            }
+        }
     }
 
     /// <summary>
@@ -197,4 +217,10 @@ public class PacketIDManager
     /// </summary>
     /// <value>The number of packet IDs currently allocated (0-65535).</value>
     public int Count => Volatile.Read(ref this.activeCount);
+
+    /// <summary>
+    /// Gets the number of packet IDs currently waiting in the reuse queue.
+    /// Intended for diagnostics and tests.
+    /// </summary>
+    internal int FreedCount => this.FreedPacketIds.Count;
 }

--- a/Tests/HiveMQtt.Test/HiveMQClient/Plan/PacketIDManagerTest.cs
+++ b/Tests/HiveMQtt.Test/HiveMQClient/Plan/PacketIDManagerTest.cs
@@ -1,9 +1,11 @@
 namespace HiveMQtt.Test.HiveMQClient.Plan;
 
+using System.Threading;
+using System.Threading.Tasks;
 using HiveMQtt.Client;
+using HiveMQtt.MQTT5.ReasonCodes;
 using HiveMQtt.MQTT5.Types;
 using Xunit;
-using System.Threading.Tasks;
 
 [Collection("Broker")]
 public class PacketIDManagerTest
@@ -27,7 +29,6 @@ public class PacketIDManagerTest
         // Testing with 500k messages, 250k QoS1 and 250k QoS2
         var qos1Messages = 250000;
         var qos2Messages = 250000;
-        var totalMessages = qos1Messages + qos2Messages;
 
         // Act
         for (var i = 0; i < qos1Messages; i++)
@@ -54,5 +55,112 @@ public class PacketIDManagerTest
 
         // Assert
         Assert.Equal(0, packetIdManager.Count); // All Packet IDs must be released
+    }
+
+    [Fact]
+    public async Task Incoming_QoS1_Traffic_Does_Not_Grow_FreedPacketIds_Async()
+    {
+        const string topic = "tests/PacketIDManager/IncomingQoS1NoLeak";
+        const int messageCount = 2000;
+
+        var publisher = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId("PacketIDManagerIncomingLeakPublisher")
+            .WithBroker("localhost")
+            .WithPort(1883)
+            .Build());
+
+        var subscriber = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId("PacketIDManagerIncomingLeakSubscriber")
+            .WithBroker("localhost")
+            .WithPort(1883)
+            .Build());
+
+        await publisher.ConnectAsync().ConfigureAwait(true);
+        await subscriber.ConnectAsync().ConfigureAwait(true);
+
+        var received = 0;
+        using var allReceived = new ManualResetEventSlim(false);
+        subscriber.OnMessageReceived += (_, _) =>
+        {
+            if (Interlocked.Increment(ref received) >= messageCount)
+            {
+                allReceived.Set();
+            }
+        };
+
+        var subResult = await subscriber.SubscribeAsync(topic, QualityOfService.AtLeastOnceDelivery).ConfigureAwait(true);
+        Assert.Equal(SubAckReasonCode.GrantedQoS1, subResult.Subscriptions[0].SubscribeReasonCode);
+
+        var packetIdManager = subscriber.Connection.GetPacketIDManager();
+        await WaitForConditionAsync(() => packetIdManager.Count == 0, TimeSpan.FromSeconds(5)).ConfigureAwait(true);
+
+        for (var i = 0; i < messageCount; i++)
+        {
+#pragma warning disable IDE0300
+            await publisher.PublishAsync(topic, new byte[] { 0x01 }, QualityOfService.AtLeastOnceDelivery).ConfigureAwait(true);
+#pragma warning restore IDE0300
+        }
+
+        Assert.True(allReceived.Wait(TimeSpan.FromSeconds(60)), $"Only received {received} of {messageCount} messages.");
+
+        // Allow in-flight PubAcks to finish
+        await Task.Delay(500).ConfigureAwait(true);
+
+        // Before the fix, FreedCount would grow ~1:1 with incoming QoS1 messages
+        Assert.Equal(messageCount, received);
+        Assert.True(
+            packetIdManager.FreedCount < 16,
+            $"FreedPacketIds grew unexpectedly: FreedCount={packetIdManager.FreedCount}, Count={packetIdManager.Count}");
+        Assert.Equal(0, packetIdManager.Count);
+
+        await publisher.DisconnectAsync().ConfigureAwait(true);
+        await subscriber.DisconnectAsync().ConfigureAwait(true);
+        publisher.Dispose();
+        subscriber.Dispose();
+    }
+
+    [Fact]
+    public async Task Subscribe_And_Unsubscribe_Release_Packet_Ids_Async()
+    {
+        const string topic = "tests/PacketIDManager/SubUnsubRelease";
+
+        var client = new HiveMQClient(new HiveMQClientOptionsBuilder()
+            .WithClientId("PacketIDManagerSubUnsubRelease")
+            .WithBroker("localhost")
+            .WithPort(1883)
+            .Build());
+
+        await client.ConnectAsync().ConfigureAwait(true);
+        var packetIdManager = client.Connection.GetPacketIDManager();
+        Assert.Equal(0, packetIdManager.Count);
+
+        for (var i = 0; i < 20; i++)
+        {
+            await client.SubscribeAsync(topic, QualityOfService.AtLeastOnceDelivery).ConfigureAwait(true);
+            await WaitForConditionAsync(() => packetIdManager.Count == 0, TimeSpan.FromSeconds(5)).ConfigureAwait(true);
+
+            await client.UnsubscribeAsync(topic).ConfigureAwait(true);
+            await WaitForConditionAsync(() => packetIdManager.Count == 0, TimeSpan.FromSeconds(5)).ConfigureAwait(true);
+        }
+
+        // Reuse queue may hold recently freed IDs, but must stay bounded by sub/unsub cycle count
+        Assert.True(packetIdManager.FreedCount <= 40, $"FreedCount={packetIdManager.FreedCount}");
+
+        await client.DisconnectAsync().ConfigureAwait(true);
+        client.Dispose();
+    }
+
+    private static async Task WaitForConditionAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (!condition())
+        {
+            if (DateTime.UtcNow > deadline)
+            {
+                Assert.True(false, $"Condition not met within {timeout.TotalSeconds}s.");
+            }
+
+            await Task.Delay(10).ConfigureAwait(true);
+        }
     }
 }

--- a/Tests/HiveMQtt.Test/Internal/PacketIDManagerUnitTest.cs
+++ b/Tests/HiveMQtt.Test/Internal/PacketIDManagerUnitTest.cs
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2024-present HiveMQ and the HiveMQ Community
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+namespace HiveMQtt.Test.Internal;
+
+using System.Threading.Tasks;
+using HiveMQtt.Client.Internal;
+using Xunit;
+
+public class PacketIDManagerUnitTest
+{
+    [Fact]
+    public async Task Allocate_Then_Free_Reuses_Freed_Id_Async()
+    {
+        var manager = new PacketIDManager();
+
+        var id1 = await manager.GetAvailablePacketIDAsync().ConfigureAwait(true);
+        Assert.Equal(1, id1);
+        Assert.Equal(1, manager.Count);
+        Assert.Equal(0, manager.FreedCount);
+
+        await manager.MarkPacketIDAsAvailableAsync(id1).ConfigureAwait(true);
+        Assert.Equal(0, manager.Count);
+        Assert.Equal(1, manager.FreedCount);
+
+        var id2 = await manager.GetAvailablePacketIDAsync().ConfigureAwait(true);
+        Assert.Equal(id1, id2);
+        Assert.Equal(1, manager.Count);
+        Assert.Equal(0, manager.FreedCount);
+    }
+
+    [Fact]
+    public async Task Free_Never_Allocated_Id_Does_Not_Grow_Queue_Async()
+    {
+        var manager = new PacketIDManager();
+
+        // Simulate a broker-assigned incoming packet ID being freed into the manager
+        await manager.MarkPacketIDAsAvailableAsync(42).ConfigureAwait(true);
+
+        Assert.Equal(0, manager.Count);
+        Assert.Equal(0, manager.FreedCount);
+    }
+
+    [Fact]
+    public async Task Double_Free_Does_Not_Grow_Queue_Async()
+    {
+        var manager = new PacketIDManager();
+
+        var id = await manager.GetAvailablePacketIDAsync().ConfigureAwait(true);
+        await manager.MarkPacketIDAsAvailableAsync(id).ConfigureAwait(true);
+        Assert.Equal(1, manager.FreedCount);
+
+        await manager.MarkPacketIDAsAvailableAsync(id).ConfigureAwait(true);
+        Assert.Equal(0, manager.Count);
+        Assert.Equal(1, manager.FreedCount);
+    }
+
+    [Fact]
+    public async Task Reset_Clears_InUse_And_Freed_Queue_Async()
+    {
+        var manager = new PacketIDManager();
+
+        var id = await manager.GetAvailablePacketIDAsync().ConfigureAwait(true);
+        await manager.MarkPacketIDAsAvailableAsync(id).ConfigureAwait(true);
+        Assert.Equal(1, manager.FreedCount);
+
+        _ = await manager.GetAvailablePacketIDAsync().ConfigureAwait(true);
+        Assert.Equal(1, manager.Count);
+
+        manager.Reset();
+
+        Assert.Equal(0, manager.Count);
+        Assert.Equal(0, manager.FreedCount);
+
+        var next = await manager.GetAvailablePacketIDAsync().ConfigureAwait(true);
+        Assert.Equal(1, next);
+    }
+}

--- a/Tests/HiveMQtt.Test/Internal/PacketIDManagerUnitTest.cs
+++ b/Tests/HiveMQtt.Test/Internal/PacketIDManagerUnitTest.cs
@@ -54,6 +54,20 @@ public class PacketIDManagerUnitTest
     }
 
     [Fact]
+    public async Task Free_Out_Of_Range_Id_Is_No_Op_Async()
+    {
+        var manager = new PacketIDManager();
+        _ = await manager.GetAvailablePacketIDAsync().ConfigureAwait(true);
+
+        await manager.MarkPacketIDAsAvailableAsync(0).ConfigureAwait(true);
+        await manager.MarkPacketIDAsAvailableAsync(-1).ConfigureAwait(true);
+        await manager.MarkPacketIDAsAvailableAsync(65536).ConfigureAwait(true);
+
+        Assert.Equal(1, manager.Count);
+        Assert.Equal(0, manager.FreedCount);
+    }
+
+    [Fact]
     public async Task Double_Free_Does_Not_Grow_Queue_Async()
     {
         var manager = new PacketIDManager();


### PR DESCRIPTION
## Summary
- Stop freeing broker-assigned incoming QoS≥1 packet IDs into `PacketIDManager` (MQTT 5 keeps client→server and server→client ID spaces independent), which was causing unbounded `FreedPacketIds` growth under subscribe-heavy load
- Harden `MarkPacketIDAsAvailableAsync` to enqueue only when an ID was actually in use; add `Reset()` on clean-session ConnAck
- Release Subscribe/Unsubscribe packet IDs on SubAck/UnsubAck; add unit and integration coverage

Fixes #379

## Test plan
- [x] Unit tests: allocate/free reuse, never-allocated free is no-op, double-free does not grow queue, Reset clears state
- [ ] Integration (broker on `:1883`): `Incoming_QoS1_Traffic_Does_Not_Grow_FreedPacketIds_Async`
- [ ] Integration: `Subscribe_And_Unsubscribe_Release_Packet_Ids_Async`
- [ ] Existing: `Send_1Mio_QoS1_QoS2_Messages_All_Ids_Released_Async`
- [ ] Optional: run reporter’s gist and confirm `freedQueueLen` stays bounded


Made with [Cursor](https://cursor.com)